### PR TITLE
fix(converter): guard forkJoin with takeUntilDestroyed

### DIFF
--- a/src/app/pages/converter/converter.component.ts
+++ b/src/app/pages/converter/converter.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { CoincapService } from '../../api/coincap.service';
 import { BehaviorSubject, forkJoin } from 'rxjs';
@@ -29,12 +30,13 @@ export class ConverterComponent {
   public errorLoadingData: BehaviorSubject<boolean> =
     new BehaviorSubject<boolean>(false);
   private coincapService: CoincapService = inject(CoincapService);
+  private destroyRef: DestroyRef = inject(DestroyRef);
 
   constructor() {
     forkJoin({
       btcAssetData: this.coincapService.getBtcAssetData(),
       ratesData: this.coincapService.getRatesData(),
-    }).subscribe({
+    }).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: ({ btcAssetData, ratesData }) => {
         this.timeLoaded = new Date();
         const gbpRateData = ratesData.data.filter(


### PR DESCRIPTION
## Summary

- Inject `DestroyRef` into `ConverterComponent`
- Pipe `takeUntilDestroyed(this.destroyRef)` onto the `forkJoin` subscription in the constructor
- Prevents potential subscription leak if component is destroyed before the API calls complete

## Test plan

- [x] Converter page loads and displays BTC/GBP data as before
- [x] No console errors on component destroy
- [ ] Navigate away from converter mid-load — confirm no errors/leaks in DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)