### PR TITLE
fix(selectors): rename exemptVehicleState to state in GallerySelectors

### DIFF
--- a/src/app/state-management/gallery-list/gallery.selectors.ts
+++ b/src/app/state-management/gallery-list/gallery.selectors.ts
@@ -7,14 +7,14 @@ const galleryState = (state: IndexState) => state.gallery;
 export class GallerySelectors {
 
   public static galleryList
-    = createSelector(galleryState, (exemptVehicleState: IGalleryState) => {
-      return exemptVehicleState.galleryData;
+    = createSelector(galleryState, (state: IGalleryState) => {
+      return state.galleryData;
     }
   );
 
   public static selectedAlbum
-    = createSelector(galleryState, (exemptVehicleState: IGalleryState) => {
-      return exemptVehicleState.selectedAlbum;
+    = createSelector(galleryState, (state: IGalleryState) => {
+      return state.selectedAlbum;
     }
   );
 


### PR DESCRIPTION
## Summary

- Renamed `exemptVehicleState` parameter to `state` in both `GallerySelectors.galleryList` and `GallerySelectors.selectedAlbum`
- Copy-paste leftover from an unrelated domain — no behaviour change

## Test plan

- [x] `ng build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)