### PR TITLE
feat(gallery): add keyboard, click, and swipe navigation for overlay

### DIFF
--- a/src/app/components/overlay/overlay-container/overlay-container.component.html
+++ b/src/app/components/overlay/overlay-container/overlay-container.component.html
@@ -28,14 +28,16 @@
     />
   }
 
-  <img
-    alt="loaded image"
-    class="modal-image"
-    [@slideAnimation]="currentIndex"
-    [ngSrc]="displayImageUrl"
-    [ngClass]="{
-      'horizontal-image': displayHorizontalOrientation,
-      'vertical-image': !displayHorizontalOrientation,
-    }"
-  />
+  @if (displayImageUrl) {
+    <img
+      alt="loaded image"
+      class="modal-image"
+      [@slideAnimation]="currentIndex"
+      [ngSrc]="displayImageUrl"
+      [ngClass]="{
+        'horizontal-image': displayHorizontalOrientation,
+        'vertical-image': !displayHorizontalOrientation,
+      }"
+    />
+  }
 </div>

--- a/src/app/components/overlay/overlay-container/overlay-container.component.html
+++ b/src/app/components/overlay/overlay-container/overlay-container.component.html
@@ -13,18 +13,25 @@
     [icon]="icons.closeModalButton"
     (click)="closeModal()"
   />
-  <!--<i class="fa fa-arrow-left modal-arrows left-arrow"-->
-  <!--aria-hidden="true"-->
-  <!--(click)="leftArrowClick()">-->
-  <!--</i>-->
-  <!--<i class="fa fa-arrow-right modal-arrows right-arrow"-->
-  <!--aria-hidden="true"-->
-  <!--(click)="rightArrowClick()">-->
-  <!--</i>-->
+  @if (currentIndex > 0) {
+    <fa-icon
+      class="modal-arrows left-arrow"
+      [icon]="icons.leftArrow"
+      (click)="navigateImage(-1)"
+    />
+  }
+  @if (albumSet()?.length && currentIndex < albumSet().length - 1) {
+    <fa-icon
+      class="modal-arrows right-arrow"
+      [icon]="icons.rightArrow"
+      (click)="navigateImage(1)"
+    />
+  }
 
   <img
     alt="loaded image"
     class="modal-image"
+    [@slideAnimation]="currentIndex"
     [ngSrc]="selectedImageUrl$ | async"
     [ngClass]="{
       'horizontal-image':

--- a/src/app/components/overlay/overlay-container/overlay-container.component.html
+++ b/src/app/components/overlay/overlay-container/overlay-container.component.html
@@ -32,11 +32,10 @@
     alt="loaded image"
     class="modal-image"
     [@slideAnimation]="currentIndex"
-    [ngSrc]="selectedImageUrl$ | async"
+    [ngSrc]="displayImageUrl"
     [ngClass]="{
-      'horizontal-image':
-        (selectedImageHorizontalOrientation$ | async) === true,
-      'vertical-image': (selectedImageHorizontalOrientation$ | async) === false,
+      'horizontal-image': displayHorizontalOrientation,
+      'vertical-image': !displayHorizontalOrientation,
     }"
   />
 </div>

--- a/src/app/components/overlay/overlay-container/overlay-container.component.scss
+++ b/src/app/components/overlay/overlay-container/overlay-container.component.scss
@@ -70,43 +70,34 @@
   }
 
   .modal-arrows {
-    z-index: 100;
-    color: white;
-    opacity: 0.4;
-    font-size: 2.5em;
-    margin: 0 50px;
-    -webkit-transition: all 0.3s ease;
-    -moz-transition: all 0.3s ease;
-    -ms-transition: all 0.3s ease;
-    -o-transition: all 0.3s ease;
-    transition: all 0.3s ease;
+    display: none;
 
-    &:hover {
-      cursor: pointer;
-      opacity: 1;
-      -webkit-transition: all 0.3s ease;
-      -moz-transition: all 0.3s ease;
-      -ms-transition: all 0.3s ease;
-      -o-transition: all 0.3s ease;
+    @media (hover: hover) {
+      z-index: 100;
+      color: white;
+      opacity: 0.4;
+      font-size: 2.5em;
+      margin: 0 50px;
       transition: all 0.3s ease;
-    }
 
-    &.left-arrow {
-      position: absolute;
-      left: 0;
-      display: inline-block;
-      -ms-transform: translate(0, 45vh); /* IE 9 */
-      -webkit-transform: translate(0, 45vh); /* Safari */
-      transform: translate(0, 45vh);
-    }
+      &:hover {
+        cursor: pointer;
+        opacity: 1;
+      }
 
-    &.right-arrow {
-      position: absolute;
-      right: 0;
-      display: inline-block;
-      -ms-transform: translate(0, 45vh); /* IE 9 */
-      -webkit-transform: translate(0, 45vh); /* Safari */
-      transform: translate(0, 45vh);
+      &.left-arrow {
+        position: absolute;
+        left: 0;
+        display: inline-block;
+        transform: translate(0, 45vh);
+      }
+
+      &.right-arrow {
+        position: absolute;
+        right: 0;
+        display: inline-block;
+        transform: translate(0, 45vh);
+      }
     }
   }
 }

--- a/src/app/components/overlay/overlay-container/overlay-container.component.ts
+++ b/src/app/components/overlay/overlay-container/overlay-container.component.ts
@@ -47,14 +47,10 @@ export class OverlayContainerComponent implements OnInit {
 
   public isModalOpen$: Observable<boolean>;
 
-  public selectedImageUrl$: Observable<string>;
-
-  public selectedImageId$: Observable<number>;
-
-  public selectedImageHorizontalOrientation$: Observable<boolean>;
-
   private isModalOpenValue: boolean;
   protected currentIndex: number = -1;
+  protected displayImageUrl: string = '';
+  protected displayHorizontalOrientation: boolean = false;
   private touchStartX: number = 0;
 
   protected icons = {
@@ -67,10 +63,6 @@ export class OverlayContainerComponent implements OnInit {
 
   ngOnInit() {
     this.isModalOpen$ = this.appFacade.modalOpen$;
-    this.selectedImageUrl$ = this.appFacade.selectedImage$;
-    this.selectedImageId$ = this.appFacade.selectedImageId$;
-    this.selectedImageHorizontalOrientation$ =
-      this.appFacade.selectedImageHorizontalOrientation$;
 
     this.isModalOpen$
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -81,13 +73,20 @@ export class OverlayContainerComponent implements OnInit {
         this.isModalOpenValue = isModalOpen;
       });
 
-    this.selectedImageId$
+    // Handles initial image open from thumbnail click
+    this.appFacade.selectedImageId$
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((id: number) => {
         const images = this.albumSet();
-        this.currentIndex = images?.length
-          ? images.findIndex((img) => img.imageId === id)
-          : -1;
+        if (!images?.length) {
+          this.currentIndex = -1;
+          return;
+        }
+        const index = images.findIndex((img) => img.imageId === id);
+        if (index === -1 || index === this.currentIndex) return;
+        this.currentIndex = index;
+        this.displayImageUrl = images[index].imgUrl;
+        this.displayHorizontalOrientation = images[index].horizontalOrient;
       });
   }
 
@@ -134,6 +133,14 @@ export class OverlayContainerComponent implements OnInit {
     if (nextIndex < 0 || nextIndex >= images.length) return;
 
     const nextImage = images[nextIndex];
+
+    // Update local state synchronously so the animation and image
+    // change happen in the same change detection cycle — no flash.
+    this.currentIndex = nextIndex;
+    this.displayImageUrl = nextImage.imgUrl;
+    this.displayHorizontalOrientation = nextImage.horizontalOrient;
+
+    // Keep store in sync for other consumers
     this.appFacade.updateSelectedImage(
       nextImage.imgUrl,
       nextImage.imageId,

--- a/src/app/components/overlay/overlay-container/overlay-container.component.ts
+++ b/src/app/components/overlay/overlay-container/overlay-container.component.ts
@@ -7,20 +7,38 @@ import {
   inject,
   input,
 } from '@angular/core';
+import {
+  animate,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
 import { Observable } from 'rxjs';
 import { AppFacade } from '../../../state-management/app/app.facade';
-import { IGalleryCover } from '../../../state-management/gallery-list/gallery-cover.interface';
+import { IAlbumImagesData } from '../../../pages/galleries/gallery-album/album-data.interface';
 import { AsyncPipe, NgClass, NgOptimizedImage } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
-import { faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faXmark, faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
     selector: 'app-overlay-container',
     templateUrl: './overlay-container.component.html',
     styleUrl: './overlay-container.component.scss',
-    imports: [AsyncPipe, NgClass, NgOptimizedImage, RouterModule, FontAwesomeModule]
+    imports: [AsyncPipe, NgClass, NgOptimizedImage, RouterModule, FontAwesomeModule],
+    animations: [
+      trigger('slideAnimation', [
+        transition(':increment', [
+          style({ opacity: 0, transform: 'translate(calc(-50% + 80px), -50%)' }),
+          animate('300ms ease-out', style({ opacity: 1, transform: 'translate(-50%, -50%)' })),
+        ]),
+        transition(':decrement', [
+          style({ opacity: 0, transform: 'translate(calc(-50% - 80px), -50%)' }),
+          animate('300ms ease-out', style({ opacity: 1, transform: 'translate(-50%, -50%)' })),
+        ]),
+      ]),
+    ],
 })
 export class OverlayContainerComponent implements OnInit {
   private appFacade = inject(AppFacade);
@@ -36,13 +54,16 @@ export class OverlayContainerComponent implements OnInit {
   public selectedImageHorizontalOrientation$: Observable<boolean>;
 
   private isModalOpenValue: boolean;
+  protected currentIndex: number = -1;
+  private touchStartX: number = 0;
 
   protected icons = {
     closeModalButton: faXmark,
+    leftArrow: faArrowLeft,
+    rightArrow: faArrowRight,
   };
 
-  public albumSet = input.required<Array<IGalleryCover>>();
-  public selectedImageId = input.required<Observable<number>>();
+  public albumSet = input.required<Array<IAlbumImagesData>>();
 
   ngOnInit() {
     this.isModalOpen$ = this.appFacade.modalOpen$;
@@ -59,6 +80,15 @@ export class OverlayContainerComponent implements OnInit {
           : this.renderer.removeClass(document.body, 'noScroll');
         this.isModalOpenValue = isModalOpen;
       });
+
+    this.selectedImageId$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((id: number) => {
+        const images = this.albumSet();
+        this.currentIndex = images?.length
+          ? images.findIndex((img) => img.imageId === id)
+          : -1;
+      });
   }
 
   @HostListener('document:keydown', ['$event'])
@@ -68,14 +98,47 @@ export class OverlayContainerComponent implements OnInit {
     }
 
     if (event.key === 'ArrowLeft' && this.isModalOpenValue) {
-      // console.log('Left button pressed');
-      // this.appFacade.updateSelectedImage('https://farm2.staticflickr.com/1964/44319436194_e6435002f1_k.jpg', 15, false);
+      this.navigateImage(-1);
     }
 
     if (event.key === 'ArrowRight' && this.isModalOpenValue) {
-      // console.log('Right button pressed');
-      // this.appFacade.updateSelectedImage('https://farm2.staticflickr.com/1932/44990793922_7754015d02_k.jpg', 13, false);
+      this.navigateImage(1);
     }
+  }
+
+  @HostListener('document:touchstart', ['$event'])
+  protected onTouchStart(event: TouchEvent): void {
+    if (this.isModalOpenValue) {
+      this.touchStartX = event.touches[0].clientX;
+    }
+  }
+
+  @HostListener('document:touchend', ['$event'])
+  protected onTouchEnd(event: TouchEvent): void {
+    if (!this.isModalOpenValue) return;
+
+    const deltaX = event.changedTouches[0].clientX - this.touchStartX;
+    const minSwipeDistance = 50;
+
+    if (Math.abs(deltaX) < minSwipeDistance) return;
+
+    // Swipe left → next image, swipe right → previous image
+    this.navigateImage(deltaX < 0 ? 1 : -1);
+  }
+
+  public navigateImage(direction: -1 | 1): void {
+    const images = this.albumSet();
+    if (this.currentIndex === -1 || !images?.length) return;
+
+    const nextIndex = this.currentIndex + direction;
+    if (nextIndex < 0 || nextIndex >= images.length) return;
+
+    const nextImage = images[nextIndex];
+    this.appFacade.updateSelectedImage(
+      nextImage.imgUrl,
+      nextImage.imageId,
+      nextImage.horizontalOrient
+    );
   }
 
   public closeModal() {

--- a/src/app/pages/galleries/gallery-album/gallery-album.component.html
+++ b/src/app/pages/galleries/gallery-album/gallery-album.component.html
@@ -37,7 +37,6 @@
   </div>
 
   <app-overlay-container
-    [selectedImageId]="selectedImageId"
     [albumSet]="(albumData | async).albumImages"
     >
   </app-overlay-container>

--- a/src/app/pages/galleries/gallery-album/gallery-album.component.ts
+++ b/src/app/pages/galleries/gallery-album/gallery-album.component.ts
@@ -32,8 +32,6 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 export class GalleryAlbumComponent {
   public pageNumber: number = 1;
 
-  public selectedImageId: number = null;
-
   private destroyRef: DestroyRef = inject(DestroyRef);
 
   private loadedImagesUrl: Array<string> = [];


### PR DESCRIPTION
## Summary
- Add left/right arrow key navigation for enlarged gallery images
- Add clickable arrow buttons (desktop only via `@media (hover: hover)`)
- Add touch swipe gesture support for mobile devices
- Add Angular slide animation on image transitions, preserving centering transform
- Hide left/right arrows at list boundaries (first/last image)
- Fix incorrect types on overlay component inputs (`IGalleryCover` → `IAlbumImagesData`, remove unused `selectedImageId` input)
- Fix empty `ngSrc` error by conditionally rendering image
- Fix image flash during navigation by updating local state synchronously

## Test plan
- [x] Open a gallery album, click an image to enlarge
- [x] Press left/right arrow keys to navigate — verify images change with slide animation
- [x] Verify left arrow hidden on first image, right arrow hidden on last image
- [x] Verify clickable arrow buttons work on desktop
- [x] Test on mobile viewport — arrows should be hidden, swipe left/right to navigate
- [x] Press Escape to close — verify still works
- [x] Verify no console errors on initial page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)