### PR TITLE
feat(gallery): keyboard, click, and swipe navigation for image overlay

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,130 @@
+# Project Kenny — Architecture
+
+## Codebase Structure
+
+```
+project-kenny/src/app/
+│
+├── app.component ─────────────── Shell (header + router-outlet + footer)
+│
+├── api/ ──────────────────────── HTTP Services
+│   ├── coincap.service          BTC price data (CoinCap API)
+│   └── profile.service          Resume/profile data
+│
+├── components/ ───────────────── Shared/Reusable Components
+│   ├── header                   Nav bar + social links
+│   ├── footer                   Footer
+│   ├── gallery-album-cover      Single image thumbnail (emits load status)
+│   ├── gallery-album-jumbotron  Album header (title, subtitle, cover)
+│   ├── overlay/
+│   │   └── overlay-container    Enlarged image modal (keyboard/swipe/click nav)
+│   └── profile-content          Resume section block
+│
+├── pages/ ────────────────────── Routed Page Components
+│   ├── home                     /home — landing page
+│   ├── profile                  /resume — resume page
+│   ├── galleries/
+│   │   ├── gallery-section      /photography — parent (router-outlet)
+│   │   ├── gallery-album-listing  /photography — album grid
+│   │   └── gallery-album        /photography/:id — album detail + overlay
+│   ├── converter                /converter — BTC calculator
+│   ├── utils                    /utils — copycat mocking tool
+│   └── notFound                 /** — 404 page
+│
+├── state-management/ ─────────── NgRx Store
+│   ├── ngrx-index               Root state (IndexState = app + gallery)
+│   │
+│   ├── app/ ──────────────────── App State (modal/overlay)
+│   │   ├── app-state.interface  { modalOpen, selectedImage, selectedImageId, ... }
+│   │   ├── app.actions          Open/Close Modal, UpdateSelectedImage/Id
+│   │   ├── app.reducers         State transitions
+│   │   ├── app.selectors        modalStatus, selectedImage, selectedImageId, ...
+│   │   └── app.facade           Public API for components
+│   │
+│   └── gallery-list/ ─────────── Gallery State
+│       ├── gallery-state.interface  { galleryList, selectedAlbumId, albumData }
+│       ├── gallery-cover.interface  IGalleryCover (album metadata)
+│       ├── social-media-links.interface
+│       ├── gallery.actions      Load/Set gallery data
+│       ├── gallery.effects      Side effects (HTTP → store)
+│       ├── gallery.reducers     State transitions
+│       ├── gallery.selectors    galleryList, albumData, ...
+│       └── gallery.facade       Public API for components
+│
+└── main.ts ───────────────────── Bootstrap + Routes + Providers
+```
+
+## Routes
+
+| Path | Component | Description |
+|------|-----------|-------------|
+| `/` | redirect → `/home` | |
+| `/home` | HomeComponent | Landing page |
+| `/resume` | ProfileComponent | Resume page |
+| `/photography` | GallerySectionComponent | Parent with router-outlet |
+| `/photography` (child) | GalleryAlbumListingComponent | Album grid |
+| `/photography/:id` (child) | GalleryAlbumComponent | Album detail + overlay |
+| `/converter` | ConverterComponent | BTC calculator |
+| `/utils` | UtilsComponent | Copycat mocking tool |
+| `/**` | NotFoundComponent | 404 page |
+
+## NgRx Store
+
+```
+IndexState
+├── app: IAppState
+│   ├── modalOpen: boolean
+│   ├── selectedImage: string (URL)
+│   ├── selectedImageId: number
+│   └── selectedImageHorizontalOrientation: boolean
+│
+└── gallery: IGalleryState
+    ├── galleryList: IGalleryCover[]
+    ├── selectedAlbumId: string
+    └── albumData: IGalleryCover
+```
+
+## Gallery Overlay Data Flow
+
+```
+User clicks thumbnail
+        │
+        ▼
+GalleryAlbumComponent.openModal()
+        │
+        ├──► AppFacade.updateSelectedImage(url, id, orient)
+        │         │
+        │         ▼
+        │    Store ──► app.reducers ──► app state updated
+        │
+        └──► AppFacade.openModal()
+                  │
+                  ▼
+             Store ──► app.reducers ──► modalOpen = true
+
+        ┌─────────────────────────────────────────────┐
+        │         OverlayContainerComponent            │
+        │                                             │
+        │  selectedImageId$ ──► currentIndex           │
+        │                  ──► displayImageUrl          │
+        │                  ──► displayHorizontalOrient  │
+        │                                             │
+        │  isModalOpen$    ──► show/hide overlay (CSS)  │
+        │                  ──► body scroll lock         │
+        │                                             │
+        │  Input: albumSet ──► image list for nav       │
+        │                                             │
+        │  Navigation (keyboard/click/swipe):           │
+        │    navigateImage() ──► update local state     │
+        │                   ──► sync store              │
+        │                   ──► [@slideAnimation]       │
+        └─────────────────────────────────────────────┘
+```
+
+### Navigation inputs
+
+- **Keyboard**: ArrowLeft / ArrowRight / Escape (HostListener on `document:keydown`)
+- **Click**: Left/right arrow buttons (desktop only, `@media (hover: hover)`)
+- **Swipe**: Touch start/end delta (mobile, HostListener on `document:touchstart`/`touchend`)
+
+All three funnel through `navigateImage(direction)` which updates local state synchronously, then syncs the store.

--- a/src/app/components/overlay/overlay-container/overlay-container.component.html
+++ b/src/app/components/overlay/overlay-container/overlay-container.component.html
@@ -33,7 +33,7 @@
       alt="loaded image"
       class="modal-image"
       [@slideAnimation]="currentIndex"
-      [ngSrc]="displayImageUrl"
+      [src]="displayImageUrl"
       [ngClass]="{
         'horizontal-image': displayHorizontalOrientation,
         'vertical-image': !displayHorizontalOrientation,

--- a/src/app/components/overlay/overlay-container/overlay-container.component.scss
+++ b/src/app/components/overlay/overlay-container/overlay-container.component.scss
@@ -23,7 +23,6 @@
     position: fixed;
     top: 50%;
     left: 50%;
-    -webkit-transform: translate(-50%, -50%); /* Safari */
     transform: translate(-50%, -50%);
 
     &.horizontal-image {

--- a/src/app/components/overlay/overlay-container/overlay-container.component.ts
+++ b/src/app/components/overlay/overlay-container/overlay-container.component.ts
@@ -29,13 +29,19 @@ import { faXmark, faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-
     imports: [AsyncPipe, NgClass, RouterModule, FontAwesomeModule],
     animations: [
       trigger('slideAnimation', [
+        transition('void => *', [
+          style({ opacity: 0, transform: 'translate(-50%, -50%)' }),
+          animate('200ms ease-out', style({ opacity: 1, transform: 'translate(-50%, -50%)' })),
+        ]),
         transition(':increment', [
-          style({ opacity: 0, transform: 'translate(calc(-50% + 80px), -50%)' }),
-          animate('300ms ease-out', style({ opacity: 1, transform: 'translate(-50%, -50%)' })),
+          animate('100ms ease-in', style({ opacity: 0 })),
+          style({ transform: 'translate(calc(-50% + 80px), -50%)' }),
+          animate('200ms ease-out', style({ opacity: 1, transform: 'translate(-50%, -50%)' })),
         ]),
         transition(':decrement', [
-          style({ opacity: 0, transform: 'translate(calc(-50% - 80px), -50%)' }),
-          animate('300ms ease-out', style({ opacity: 1, transform: 'translate(-50%, -50%)' })),
+          animate('100ms ease-in', style({ opacity: 0 })),
+          style({ transform: 'translate(calc(-50% - 80px), -50%)' }),
+          animate('200ms ease-out', style({ opacity: 1, transform: 'translate(-50%, -50%)' })),
         ]),
       ]),
     ],
@@ -93,7 +99,7 @@ export class OverlayContainerComponent implements OnInit {
   @HostListener('document:keydown', ['$event'])
   protected keyPress(event: KeyboardEvent): void {
     if (event.key === 'Escape' && this.isModalOpenValue) {
-      this.appFacade.closeModal();
+      this.closeModal();
     }
 
     if (event.key === 'ArrowLeft' && this.isModalOpenValue) {
@@ -150,5 +156,7 @@ export class OverlayContainerComponent implements OnInit {
 
   public closeModal() {
     this.appFacade.closeModal();
+    this.displayImageUrl = '';
+    this.currentIndex = -1;
   }
 }

--- a/src/app/components/overlay/overlay-container/overlay-container.component.ts
+++ b/src/app/components/overlay/overlay-container/overlay-container.component.ts
@@ -16,7 +16,7 @@ import {
 import { Observable } from 'rxjs';
 import { AppFacade } from '../../../state-management/app/app.facade';
 import { IAlbumImagesData } from '../../../pages/galleries/gallery-album/album-data.interface';
-import { AsyncPipe, NgClass, NgOptimizedImage } from '@angular/common';
+import { AsyncPipe, NgClass } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
@@ -26,7 +26,7 @@ import { faXmark, faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-
     selector: 'app-overlay-container',
     templateUrl: './overlay-container.component.html',
     styleUrl: './overlay-container.component.scss',
-    imports: [AsyncPipe, NgClass, NgOptimizedImage, RouterModule, FontAwesomeModule],
+    imports: [AsyncPipe, NgClass, RouterModule, FontAwesomeModule],
     animations: [
       trigger('slideAnimation', [
         transition(':increment', [


### PR DESCRIPTION
## Summary
- Add left/right arrow key navigation for enlarged gallery images
- Add clickable arrow buttons (desktop only via `@media (hover: hover)`)
- Add touch swipe gesture support for mobile devices
- Add Angular slide animation (two-phase: fade-out then slide-in) on image transitions
- Hide left/right arrows at list boundaries (first/last image)
- Fix incorrect types on overlay component inputs (`IGalleryCover` → `IAlbumImagesData`, remove unused `selectedImageId` input)
- Fix empty `ngSrc` error — switched to plain `[src]` (modal image loads on interaction, not page load)
- Fix image flash by updating local state synchronously before store dispatch
- Fix re-open flash by resetting state on `closeModal()` so stale image is never shown
- Fix Escape key bypassing state reset
- Add codebase architecture doc (`ARCHITECTURE.md`)

## Test plan
- [x] Open a gallery album, click an image to enlarge
- [x] Press left/right arrow keys to navigate — verify images change with slide animation
- [x] Verify left arrow hidden on first image, right arrow hidden on last image
- [x] Verify clickable arrow buttons work on desktop
- [x] Test on mobile viewport — arrows should be hidden, swipe left/right to navigate
- [x] Press Escape to close — verify still works
- [x] Verify no console errors on initial page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)