### PR TITLE
Update schedule page access key

### DIFF
--- a/src/app/pages/jp-2026-schedule/jp-2026-schedule.guard.ts
+++ b/src/app/pages/jp-2026-schedule/jp-2026-schedule.guard.ts
@@ -1,7 +1,7 @@
 import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 
-const ACCESS_KEY = 'kl-jp-2026';
+const ACCESS_KEY = '1204';
 
 export const jp2026ScheduleGuard: CanActivateFn = (route) => {
   const router = inject(Router);


### PR DESCRIPTION
## Summary
- Update access key for the JP 2026 schedule page

## Test plan
- [ ] Navigate to `/jp-2026-schedule` without key — should redirect to home
- [ ] Navigate to `/jp-2026-schedule?key=1204` — should show itinerary

🤖 Generated with [Claude Code](https://claude.com/claude-code)