### PR TITLE
Lazy load gallery content on photography route

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,4 @@
-import { Component, inject } from '@angular/core';
-import { GalleryFacade } from './state-management/gallery-list/gallery.facade';
+import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { HeaderComponent } from './components/header/header.component';
 
@@ -12,10 +11,4 @@ import { HeaderComponent } from './components/header/header.component';
         RouterOutlet,
     ]
 })
-export class AppComponent {
-  private galleryFacade = inject(GalleryFacade);
-
-  constructor() {
-    this.galleryFacade.loadGalleryList();
-  }
-}
+export class AppComponent {}

--- a/src/app/pages/galleries/gallery-section/gallery-section.component.ts
+++ b/src/app/pages/galleries/gallery-section/gallery-section.component.ts
@@ -1,9 +1,16 @@
-import { Component } from '@angular/core'
+import { Component, inject } from '@angular/core'
 import { RouterModule } from '@angular/router'
+import { GalleryFacade } from '../../../state-management/gallery-list/gallery.facade'
 
 @Component({
     selector: 'app-gallery-section',
     templateUrl: './gallery-section.component.html',
     imports: [RouterModule]
 })
-export class GallerySectionComponent {}
+export class GallerySectionComponent {
+  private galleryFacade = inject(GalleryFacade);
+
+  constructor() {
+    this.galleryFacade.loadGalleryList();
+  }
+}


### PR DESCRIPTION
## Summary
- Move `loadGalleryList()` from `AppComponent` to `GallerySectionComponent`
- `gallery-content.json` is now only fetched when navigating to `/photography`, not on every page load

## Test plan
- [ ] Navigate to `/home` — verify no `gallery-content.json` request in network tab
- [ ] Navigate to `/photography` — verify gallery loads correctly
- [ ] Navigate to a specific album — verify album data displays

🤖 Generated with [Claude Code](https://claude.com/claude-code)