### PR TITLE
Redesign converter page UI and improve API error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,11 @@ Thumbs.db
 /blob-report/
 /playwright/.cache/
 /.playwright-mcp/
+
+# Docker
+.dockerignore
+Dockerfile
+nginx.conf
+
+# Playwright tests
+/pw-tests/

--- a/src/app/pages/converter/converter.component.html
+++ b/src/app/pages/converter/converter.component.html
@@ -1,80 +1,96 @@
-<div class="center animate__animated animate__fadeIn">
-  <div class="converter">
-    <h4>A pointless BTC-GBP converter</h4>
-    <p>How much is your Bitcoin worth? Chuck in some numbers and find out!</p>
-    <p>
-      <u
-        >Disclaimer: this is "for fun", no data or input is stored or
-        tracked.</u
-      >
-    </p>
-    @if (errorLoadingData | async) {
-    <p class="error-block">
-      Error loading data! Please check browser console for more details!
-    </p>
-    } @else {
-    <div>
-      <span class="input-text"
-        >BTC price @if (!(alteredBtcPrice | async)) {
-        <span
-          >(Value loaded from Coinbase Pro at
-          {{ timeLoaded | date : 'longTime' }})</span
-        >
+<div class="page-wrapper animate__animated animate__fadeIn">
+  <div class="converter-card" [class.is-loading]="isLoadingData | async">
+
+    <div class="card-header">
+      <div class="card-title">
+        <span class="btc-dot"></span>
+        BTC–GBP
+      </div>
+      <div class="rate-chip">
+        @if (isLoadingData | async) {
+          <span class="rate-chip__text">Fetching rate…</span>
+        } @else if (errorLoadingData | async) {
+          <span class="rate-chip__text">Manual mode</span>
         } @else {
-        <span>(altered)</span>
-        } :</span
-      >
+          <span class="rate-chip__live"></span>
+          <span class="rate-chip__text">
+            1 ₿ = {{ btcPrice | currency : 'GBP' }}
+            @if (alteredBtcPrice | async) {
+              <em>(edited)</em>
+            }
+          </span>
+        }
+      </div>
+    </div>
+
+    @if (errorLoadingData | async) {
+      <div class="error-block">
+        Couldn't fetch the live rate — enter the BTC price manually to continue.
+      </div>
+    }
+
+    <div class="rate-row">
+      <span class="rate-label">BTC price in GBP</span>
       <input
+        class="rate-input"
         type="number"
         [ngModel]="btcPrice"
         (ngModelChange)="updateBtcPriceAndRecalculate($event)"
         [disabled]="isLoadingData | async"
+        placeholder="Enter rate"
       />
     </div>
-    <div>
-      BTC amount:
-      <input
-        type="number"
-        [ngModel]="btcValue"
-        (ngModelChange)="updateBTCandRecalculate($event)"
-        placeholder="Enter value"
-        [disabled]="isLoadingData | async"
-        (focus)="updateFocusedInput('btc')"
-      />
+
+    <div class="exchange-row">
+      <div class="exchange-col exchange-col--btc">
+        <span class="exchange-label">Bitcoin</span>
+        <div class="exchange-input-wrap">
+          <span class="exchange-symbol">₿</span>
+          <input
+            type="number"
+            class="exchange-input"
+            [ngModel]="btcValue"
+            (ngModelChange)="updateBTCandRecalculate($event)"
+            placeholder="0"
+            [disabled]="isLoadingData | async"
+            (focus)="updateFocusedInput('btc')"
+          />
+        </div>
+      </div>
+
+      <div class="exchange-divider">⇄</div>
+
+      <div class="exchange-col exchange-col--gbp">
+        <span class="exchange-label">Pound Sterling</span>
+        <div class="exchange-input-wrap">
+          <span class="exchange-symbol">£</span>
+          <input
+            type="number"
+            class="exchange-input"
+            [ngModel]="gbpValue"
+            (ngModelChange)="updateGBPandRecalculate($event)"
+            placeholder="0"
+            [disabled]="isLoadingData | async"
+            (focus)="updateFocusedInput('gbp')"
+          />
+        </div>
+      </div>
     </div>
-    <div>
-      GBP value:
-      <input
-        type="number"
-        [ngModel]="gbpValue"
-        (ngModelChange)="updateGBPandRecalculate($event)"
-        placeholder="Enter value"
-        [disabled]="isLoadingData | async"
-        (focus)="updateFocusedInput('gbp')"
-      />
-    </div>
+
+    @if (gbpValue) {
+      <div class="summary">
+        {{
+          ((focusedInput$ | async) === 'gbp'
+            ? (gbpValue | currency : 'GBP')
+            : btcValue + btcSymbol) +
+            ' is approximately equivalent to ' +
+            ((focusedInput$ | async) === 'gbp'
+              ? btcValue + btcSymbol
+              : (gbpValue | currency : 'GBP'))
+        }}
+      </div>
     }
+
+    <p class="disclaimer">For fun only — no data or input is stored or tracked.</p>
   </div>
 </div>
-@if (!(errorLoadingData | async)) {
-<div class="converter-summary animate__animated animate__fadeIn">
-  <p>
-    The price of BTC is currently set to
-    <b>{{ btcPrice | currency : 'GBP' }} (GBP) </b>
-    per bitcoin
-  </p>
-  @if (gbpValue) {
-  <p>
-    {{
-      ((focusedInput$ | async) === 'gbp'
-        ? (gbpValue | currency : 'GBP')
-        : btcValue + btcSymbol) +
-        ' is approximately equivilent to ' +
-        ((focusedInput$ | async) === 'gbp'
-          ? btcValue + btcSymbol
-          : (gbpValue | currency : 'GBP'))
-    }}
-  </p>
-  }
-</div>
-}

--- a/src/app/pages/converter/converter.component.scss
+++ b/src/app/pages/converter/converter.component.scss
@@ -1,59 +1,266 @@
-input {
-  color: black;
-}
+$btc: #f7931a;
+$gbp: #4caf82;
+$card-bg: rgba(10, 10, 10, 0.88);
+$border: rgba(255, 255, 255, 0.12);
+$surface: rgba(255, 255, 255, 0.09);
+$muted: rgba(255, 255, 255, 0.5);
 
-* {
-  text-align: center;
-}
-
-.input-text {
-  text-align: left;
-  width: 100%;
-}
-
-/* Chrome, Safari, Edge, Opera */
+// hide number spinners
 input::-webkit-outer-spin-button,
 input::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
 
-/* Firefox */
 input[type='number'] {
   -moz-appearance: textfield;
 }
 
-.converter {
+.page-wrapper {
   display: flex;
-  flex-direction: column;
-  justify-self: center;
-  justify-content: space-between;
-  width: 75%;
-  border: black solid 1px;
-  background-color: bisque;
-  border-radius: 10px;
-  padding: 10px;
-  margin-bottom: 15px;
+  justify-content: center;
+  padding: 2rem 1rem 3rem;
+}
 
-  * {
-    color: black;
-  }
+.converter-card {
+  width: 100%;
+  max-width: 540px;
+  background: $card-bg;
+  backdrop-filter: blur(40px);
+  -webkit-backdrop-filter: blur(40px);
+  border: 1px solid $border;
+  border-radius: 20px;
+  padding: 2rem;
+  transition: opacity 0.3s;
 
-  p.error-block {
-    color: red;
-    font-weight: 700;
-    padding: 15px;
-    border: 1px solid black;
-    border-radius: 10px;
+  &.is-loading {
+    opacity: 0.7;
   }
 
   @media (max-width: 430px) {
-    width: 100%;
+    border-radius: 14px;
+    padding: 1.25rem;
   }
 }
 
-.center {
+// ── Header ──────────────────────────────────────────────────
+.card-header {
   display: flex;
-  flex-direction: row;
-  justify-content: center;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+
+.card-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.3rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: #fff;
+}
+
+.btc-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: $btc;
+  box-shadow: 0 0 10px rgba($btc, 0.65);
+  flex-shrink: 0;
+}
+
+.rate-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: $surface;
+  border: 1px solid $border;
+  border-radius: 999px;
+  padding: 0.3rem 0.8rem;
+  font-size: 0.76rem;
+  color: $muted;
+  white-space: nowrap;
+
+  em {
+    font-style: normal;
+    color: $btc;
+  }
+}
+
+.rate-chip__live {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #4ade80;
+  flex-shrink: 0;
+  animation: blink 2s ease-in-out infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.25; }
+}
+
+// ── Error ────────────────────────────────────────────────────
+.error-block {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-radius: 10px;
+  padding: 1rem;
+  text-align: center;
+  color: #fca5a5;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+}
+
+// ── Rate row ─────────────────────────────────────────────────
+.rate-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  background: $surface;
+  border: 1px solid $border;
+  border-radius: 10px;
+  padding: 0.6rem 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.rate-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  color: $muted;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.rate-input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #fff;
+  text-align: right;
+
+  &:disabled { opacity: 0.35; }
+}
+
+// ── Exchange inputs ──────────────────────────────────────────
+.exchange-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 0.6rem;
+  margin-bottom: 1.5rem;
+}
+
+.exchange-col {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.exchange-label {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: $muted;
+  padding: 0 0.2rem;
+}
+
+.exchange-input-wrap {
+  display: flex;
+  align-items: stretch;
+  border: 1px solid $border;
+  border-radius: 12px;
+  overflow: hidden;
+  transition: border-color 0.2s;
+
+  &:focus-within {
+    border-color: rgba(255, 255, 255, 0.28);
+  }
+}
+
+.exchange-col--btc .exchange-input-wrap {
+  border-bottom: 2px solid $btc;
+}
+
+.exchange-col--gbp .exchange-input-wrap {
+  border-bottom: 2px solid $gbp;
+}
+
+.exchange-symbol {
+  display: flex;
+  align-items: center;
+  padding: 0 0.6rem 0 0.8rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  background: $surface;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.exchange-col--btc .exchange-symbol { color: $btc; }
+.exchange-col--gbp .exchange-symbol { color: $gbp; }
+
+.exchange-input {
+  flex: 1;
+  min-width: 0;
+  width: 100%;
+  background: transparent;
+  border: none;
+  outline: none;
+  font-family: inherit;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #fff;
+  padding: 0.75rem 0.7rem 0.75rem 0.4rem;
+
+  &::placeholder {
+    color: rgba(255, 255, 255, 0.18);
+    font-weight: 400;
+  }
+
+  &:disabled { opacity: 0.35; }
+}
+
+.exchange-divider {
+  font-size: 1rem;
+  color: $muted;
+  user-select: none;
+  padding-top: 1.3rem;
+  text-align: center;
+}
+
+// ── Summary ──────────────────────────────────────────────────
+.summary {
+  background: $surface;
+  border: 1px solid $border;
+  border-radius: 10px;
+  padding: 0.875rem 1rem;
+  font-size: 0.875rem;
+  color: $muted;
+  text-align: center;
+  line-height: 1.55;
+  margin-bottom: 1rem;
+}
+
+// ── Disclaimer ───────────────────────────────────────────────
+.disclaimer {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: rgba(255, 255, 255, 0.22);
+  text-align: center;
+  margin: 0;
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }

--- a/src/app/pages/converter/converter.component.ts
+++ b/src/app/pages/converter/converter.component.ts
@@ -3,11 +3,11 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { CoincapService } from '../../api/coincap.service';
 import { BehaviorSubject, forkJoin } from 'rxjs';
-import { AsyncPipe, CurrencyPipe, DatePipe } from '@angular/common';
+import { AsyncPipe, CurrencyPipe } from '@angular/common';
 
 @Component({
     selector: 'app-converter',
-    imports: [AsyncPipe, CurrencyPipe, DatePipe, FormsModule],
+    imports: [AsyncPipe, CurrencyPipe, FormsModule],
     providers: [CoincapService],
     templateUrl: './converter.component.html',
     styleUrl: './converter.component.scss'
@@ -16,7 +16,6 @@ export class ConverterComponent {
   public btcPrice: number = 0;
   public btcValue: number = null;
   public btcSymbol: string = null;
-  public timeLoaded: Date = null;
   public gbpValue: number = null;
   public btcAssetData: any = {};
   public focusedInput$: BehaviorSubject<string> = new BehaviorSubject<string>(
@@ -38,20 +37,25 @@ export class ConverterComponent {
       ratesData: this.coincapService.getRatesData(),
     }).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: ({ btcAssetData, ratesData }) => {
-        this.timeLoaded = new Date();
+        if (!ratesData?.data || !btcAssetData?.data) {
+          console.error('Unexpected API response shape', { btcAssetData, ratesData });
+          this.errorLoadingData.next(true);
+          this.isLoadingData.next(false);
+          return;
+        }
         const gbpRateData = ratesData.data.filter(
           (rate) => rate.id === 'british-pound-sterling'
         )[0];
         const btcRateData = ratesData.data.filter(
           (rate) => rate.id === 'bitcoin'
         )[0];
-        this.btcSymbol = btcRateData.currencySymbol;
+        this.btcSymbol = btcRateData?.currencySymbol ?? '₿';
         const priceOfBtcInUsd: number = Math.trunc(btcAssetData.data[0]);
         const gbpRateToUsd: number = gbpRateData?.rateUsd;
         this.btcPrice = Math.trunc(priceOfBtcInUsd * (1 / gbpRateToUsd));
       },
       error: (error) => {
-        console.log(error);
+        console.error('CoinCap API error', error);
         this.errorLoadingData.next(true);
         this.isLoadingData.next(false);
       },


### PR DESCRIPTION
## Summary

- Full dark glassmorphism redesign matching the site's dark aesthetic — replaces the bisque card with a translucent dark panel, heavy blur, and white text
- Two-column BTC ⇄ GBP exchange layout with Bitcoin orange (`#F7931A`) and GBP green (`#4CAF82`) accent duality; live rate chip with pulsing dot in the header
- Manual entry fallback when CoinCap API rate limit is exceeded — error banner is shown but all inputs remain enabled so users can still convert
- Defensive guard against unexpected API response shapes (falls into error state cleanly instead of crashing)
- Removed unused `DatePipe` import and `timeLoaded` field
- Added Docker, nginx, and pw-tests to `.gitignore`

## Test plan

- [ ] Visit `/converter` — card loads with live BTC rate chip and both inputs functional
- [ ] Edit the BTC price field — chip switches to "(edited)"
- [ ] Enter a BTC or GBP value — summary line appears with correct conversion
- [ ] Simulate API failure (block network) — error banner shown, inputs still usable for manual entry
- [ ] Check mobile layout (≤430px) — card fills width with reduced padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)