### PR TITLE
Redesign resume page with glass card, skill chips, and timeline

### DIFF
--- a/src/app/components/profile-content/profile-content.component.html
+++ b/src/app/components/profile-content/profile-content.component.html
@@ -1,31 +1,30 @@
 @for (item of fileContent(); track $index) {
-  <h4>{{ item.section }}</h4>
-  @for (content of item.sectionContents; track content) {
-    <div>
-      @if (content.header) {
-        <div class="file_content__header__padding"></div>
+  <div class="timeline-section">
+    <h4 class="section-label">{{ item.section }}</h4>
+    <div class="timeline">
+      @for (content of item.sectionContents; track content) {
+        <div class="timeline-entry">
+          @if (content.header) {
+            <div class="timeline-entry__header">
+              <span class="timeline-entry__company">{{ content.header }}</span>
+              <span class="timeline-entry__year">{{ content.year }}</span>
+            </div>
+            <span class="timeline-entry__role">{{ content.roleTitle }}</span>
+          } @else {
+            <div class="timeline-entry__header">
+              <span class="timeline-entry__role">{{ content.roleTitle }}</span>
+              <span class="timeline-entry__year">{{ content.year }}</span>
+            </div>
+          }
+          @if (content.contents?.length) {
+            <ul class="timeline-entry__details">
+              @for (point of content.contents; track point) {
+                <li>{{ point }}</li>
+              }
+            </ul>
+          }
+        </div>
       }
-      <div class="profile_main">
-        @if (content.header) {
-          <h5>
-            <strong>{{ content.header }}</strong>
-          </h5>
-          } @if (!content.header) {
-          <h6>{{ '&nbsp; ' + content.roleTitle }}</h6>
-        }
-        <h5 class="year">{{ content.year }}</h5>
-      </div>
-      @if (content.roleTitle && content.header) {
-        <h6>&nbsp; {{ content.roleTitle }}</h6>
-      }
-      <ul class="profile_details">
-        @for (contentsItem of content.contents; track contentsItem) {
-          <li>
-            {{ contentsItem }}
-          </li>
-        }
-      </ul>
     </div>
-  }
-  <hr />
+  </div>
 }

--- a/src/app/components/profile-content/profile-content.component.scss
+++ b/src/app/components/profile-content/profile-content.component.scss
@@ -1,23 +1,92 @@
+$border: rgba(255, 255, 255, 0.1);
+$muted: rgba(255, 255, 255, 0.5);
+
 :host {
-  --sub-text-color: rgb(255, 255, 255, 0.8);
+  display: block;
+}
 
-  .profile_main {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+.section-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: $muted;
+  margin: 0 0 1rem;
+}
+
+.timeline-section {
+  padding-top: 1.5rem;
+  border-top: 1px solid $border;
+  margin-top: 1.5rem;
+}
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border-left: 2px solid rgba(255, 255, 255, 0.12);
+  margin-left: 0.25rem;
+}
+
+.timeline-entry {
+  position: relative;
+  padding: 0.1rem 0 1.25rem 1.25rem;
+
+  &::before {
+    content: '';
+    position: absolute;
+    left: -5px;
+    top: 0.45rem;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.35);
+    border: 2px solid rgba(255, 255, 255, 0.12);
   }
 
-  .year {
-    color: var(--sub-text-color);
+  &:last-child {
+    padding-bottom: 0;
   }
+}
 
-  .file_content__header__padding {
-    margin-top: 20px;
-  }
+.timeline-entry__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  margin-bottom: 0.2rem;
+}
 
-  .profile_details {
-    li {
-      color: var(--sub-text-color);
-    }
+.timeline-entry__company {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #fff;
+}
+
+.timeline-entry__role {
+  display: block;
+  font-size: 0.83rem;
+  color: $muted;
+  margin-bottom: 0.5rem;
+}
+
+.timeline-entry__year {
+  font-size: 0.75rem;
+  color: $muted;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.timeline-entry__details {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  li {
+    font-size: 0.83rem;
+    color: rgba(255, 255, 255, 0.65);
+    line-height: 1.5;
   }
 }

--- a/src/app/pages/profile/profile.component.html
+++ b/src/app/pages/profile/profile.component.html
@@ -1,71 +1,82 @@
 @if (isContentLoaded()) {
-<div class="profile_content animate__animated animate__fadeIn">
-  <div class="personal_info">
-    <div class="personal_info__text">
-      <h2>Kenny Lai</h2>
-      <span class="personal_info__professional_role">
-        <fa-icon [icon]="icons.briefcase" />
-        <h5>Software Developer</h5>
-      </span>
-      <span class="personal_info__location"
-        ><fa-icon [icon]="icons.globe" />
-        <h5>Basingstoke, United Kingdom</h5>
-      </span>
+<div class="profile-card animate__animated animate__fadeIn">
+
+  <!-- Header -->
+  <div class="profile-header">
+    <div class="profile-header__text">
+      <h2 class="profile-name">Kenny Lai</h2>
+      <div class="profile-badges">
+        <span class="badge"><fa-icon [icon]="icons.briefcase" />Software Developer</span>
+        <span class="badge"><fa-icon [icon]="icons.globe" />Basingstoke, UK</span>
+      </div>
     </div>
-    <div class="personal_info__image">
-      <img
-        alt="profile picture"
-        class="profile_image"
-        [ngClass]="{
-          'hide-image': !pictureLoaded(),
-          'show-image': pictureLoaded(),
-        }"
-        ngSrc="https://d1gzhm7v07i91z.cloudfront.net/Selfie1.jpg"
-        height="200"
-        width="200"
-        (load)="pictureLoaded.set(true)"
-        priority
-      />
+    <img
+      alt="profile picture"
+      class="profile-photo"
+      [ngClass]="{ 'hide-image': !pictureLoaded(), 'show-image': pictureLoaded() }"
+      ngSrc="https://d1gzhm7v07i91z.cloudfront.net/Selfie1.jpg"
+      height="200"
+      width="200"
+      (load)="pictureLoaded.set(true)"
+      priority
+    />
+  </div>
+
+  <!-- About -->
+  <div class="section">
+    <h4 class="section-label">About</h4>
+    <p class="section-body">
+      A reliable, optimistic, hardworking and easy-going Software Developer keen on
+      technology and willing to put effort into learning and mastering what is needed.
+      Easily adaptable to different environments and able to work under pressure with
+      tight deadlines.
+    </p>
+  </div>
+
+  <!-- Skills -->
+  <div class="section">
+    <h4 class="section-label">Skills</h4>
+    <div class="skill-groups">
+      <div class="skill-group">
+        <span class="skill-group__label">Languages</span>
+        <div class="chips">
+          <span class="chip">JavaScript</span>
+          <span class="chip">TypeScript</span>
+          <span class="chip">HTML</span>
+          <span class="chip">CSS / SCSS</span>
+        </div>
+      </div>
+      <div class="skill-group">
+        <span class="skill-group__label">Frontend</span>
+        <div class="chips">
+          <span class="chip">Angular</span>
+          <span class="chip">React</span>
+          <span class="chip">Redux</span>
+          <span class="chip">NgRx</span>
+        </div>
+      </div>
+      <div class="skill-group">
+        <span class="skill-group__label">Backend</span>
+        <div class="chips">
+          <span class="chip">NestJS</span>
+        </div>
+      </div>
+      <div class="skill-group">
+        <span class="skill-group__label">Tools</span>
+        <div class="chips">
+          <span class="chip">Git / GitHub</span>
+          <span class="chip">GitHub Actions</span>
+          <span class="chip">AWS</span>
+        </div>
+      </div>
     </div>
   </div>
 
-  <hr />
-  <h4>About</h4>
-  <p>
-    A reliable, optimistic, hardworking and easy-going Software Developer that
-    is keen on technology and willing to put effort into learning and mastering
-    what is needed of him. Easily adaptable to different environments and can
-    work under pressure with tight deadlines.
-  </p>
-
-  <hr />
-
-  <h4>Skills</h4>
-
-  <ul>
-    <li>Programming languages</li>
-    <ul>
-      <li>Javascript | Typescript | HTML | CSS | SCSS</li>
-    </ul>
-    <li>Frontend development</li>
-    <ul>
-      <li>Angular | React | Redux | NgRx</li>
-    </ul>
-    <li>Backend development</li>
-    <ul>
-      <li>NestJS</li>
-    </ul>
-    <li>Tools</li>
-    <ul>
-      <li>Git/Github/Github actions | AWS</li>
-    </ul>
-  </ul>
-
-  <hr />
-
-  <div class="app_profile_content">
+  <!-- Experience / Education (dynamic) -->
+  <div class="section">
     <app-profile-content [fileContent]="profileContent()"></app-profile-content>
   </div>
+
 </div>
 } @else {
 <div class="loading-spinner">

--- a/src/app/pages/profile/profile.component.scss
+++ b/src/app/pages/profile/profile.component.scss
@@ -1,77 +1,167 @@
+$border: rgba(255, 255, 255, 0.1);
+$surface: rgba(255, 255, 255, 0.06);
+$muted: rgba(255, 255, 255, 0.5);
+
 :host {
-  --sub-text-color: rgb(255, 255, 255, 0.8);
+  display: block;
+  padding: 24px 1rem 3rem;
+}
 
-  .loading-spinner {
-    display: flex;
+// ── Card ─────────────────────────────────────────────────────
+
+.profile-card {
+  max-width: 780px;
+  margin: 0 auto;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border: 1px solid $border;
+  border-radius: 20px;
+  padding: 2rem;
+
+  @media (max-width: 600px) {
+    padding: 1.25rem;
+    border-radius: 14px;
+  }
+}
+
+// ── Header ────────────────────────────────────────────────────
+
+.profile-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.profile-header__text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.profile-name {
+  font-size: 2rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin: 0;
+  color: #fff;
+}
+
+.profile-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: $surface;
+  border: 1px solid $border;
+  border-radius: 999px;
+  padding: 0.3rem 0.75rem;
+  font-size: 0.8rem;
+  color: $muted;
+
+  fa-icon {
+    font-size: 0.75rem;
+  }
+}
+
+.profile-photo {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid rgba(255, 255, 255, 0.2);
+  flex-shrink: 0;
+  transition: opacity 1s ease;
+
+  &.hide-image { opacity: 0; }
+  &.show-image { opacity: 1; }
+}
+
+// ── Sections ──────────────────────────────────────────────────
+
+.section {
+  padding-top: 1.5rem;
+  border-top: 1px solid $border;
+  margin-top: 1.5rem;
+
+  &:first-of-type {
+    margin-top: 0;
+  }
+}
+
+.section-label {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: $muted;
+  margin: 0 0 1rem;
+}
+
+.section-body {
+  color: rgba(255, 255, 255, 0.75);
+  line-height: 1.7;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+// ── Skills chips ──────────────────────────────────────────────
+
+.skill-groups {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.skill-group {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+
+  @media (max-width: 480px) {
     flex-direction: column;
-    justify-content: center;
-    align-items: center;
+    gap: 0.4rem;
   }
+}
 
-  p {
-    color: var(--sub-text-color);
-  }
+.skill-group__label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: $muted;
+  width: 80px;
+  flex-shrink: 0;
+  padding-top: 0.3rem;
+}
 
-  .profile_content {
-    margin-top: 24px;
-    margin-left: 15%;
-    margin-right: 15%;
-  }
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
 
-  .personal_info {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-  }
+.chip {
+  display: inline-block;
+  background: $surface;
+  border: 1px solid $border;
+  border-radius: 6px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.8);
+}
 
-  .hide-image {
-    opacity: 0;
-    visibility: hidden;
-  }
+// ── Loading ───────────────────────────────────────────────────
 
-  .show-image {
-    opacity: 1;
-    visibility: visible;
-    -webkit-transition: opacity 1s ease;
-    -moz-transition: opacity 1s ease;
-    -ms-transition: opacity 1s ease;
-    -o-transition: opacity 1s ease;
-    transition: opacity 1s ease;
-  }
-
-  .personal_info__location,
-  .personal_info__professional_role {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    fa-icon {
-      padding-right: 5px;
-    }
-    h5 {
-      margin-bottom: 0;
-    }
-  }
-
-  .app_profile_content {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .profile_image {
-    border: solid 1px black;
-  }
-
-  @media (min-width: 1024px) {
-    .profile_content {
-      margin-left: 15%;
-      margin-right: 15%;
-    }
-  }
-
-  @media (min-width: 480px) {
-    .profile_content {
-      margin-left: 15%;
-      margin-right: 15%;
-    }
-  }
+.loading-spinner {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 4rem;
 }


### PR DESCRIPTION
## Summary

- Frosted-glass card wrapping the entire page, consistent with the converter and nav aesthetic
- Circular profile photo with subtle ring border; name enlarged with bolder weight
- Job title and location as pill badges with icons instead of raw `<h5>` tags
- Skills section replaced: nested `<ul>` → chip tags grouped by category label (Languages, Frontend, Backend, Tools)
- Work/education timeline: left vertical rule with dot markers, company bold/white, role muted below, year right-aligned
- Unified section headers across both components: tiny uppercase, letter-spaced, muted

## Test plan

- [ ] Visit `/resume` — glass card loads with profile photo, badges, and skills chips visible
- [ ] Skills chips render in correct groups with no overflow on mobile
- [ ] Dynamic profile content (experience/education) renders as timeline with dots and left rule
- [ ] Profile photo fades in correctly after load
- [ ] Layout is readable at mobile widths (≤480px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)