### PR TITLE
Redesign photography routes with grid layout, improved UX and lazy loading

### DIFF
--- a/src/app/components/gallery-album-cover/gallery-album-cover.component.scss
+++ b/src/app/components/gallery-album-cover/gallery-album-cover.component.scss
@@ -1,60 +1,66 @@
 :host {
+  display: block;
+
   img.album-cover {
     opacity: 0;
     display: block;
     height: 200%;
+    min-width: 100%;
+    max-width: none;
   }
 
   img.album-cover.ng-lazyloaded {
     opacity: 1;
-    -moz-transition: all 1s;
-    -webkit-transition: all 1s;
-    transition: all 1s;
+    transition: opacity 0.8s ease, transform 0.4s ease;
   }
 
   .gallery-container {
     position: relative;
-    width: 250px;
-    height: 250px;
+    width: 100%;
+    aspect-ratio: 1 / 1;
     overflow: hidden;
-
-    &:hover {
-      cursor: pointer;
-    }
+    border-radius: 10px;
+    cursor: pointer;
+    background: rgba(255, 255, 255, 0.06);
   }
 
   .overlay {
     position: absolute;
-    opacity: 0;
     top: 0;
-    bottom: 0;
     left: 0;
     right: 0;
-    height: 100%;
-    width: 100%;
-    transition: 1s ease;
-    background-color: rgba(0, 0, 0, 0.5);
+    bottom: 0;
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    background: linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.78) 0%,
+      rgba(0, 0, 0, 0.25) 45%,
+      transparent 100%
+    );
+    pointer-events: none;
+  }
+
+  .text {
+    position: absolute;
+    bottom: 12px;
+    left: 14px;
+    right: 14px;
+    color: #fff;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-align: left;
+    letter-spacing: 0.01em;
+    line-height: 1.3;
+    text-shadow: 0 1px 6px rgba(0, 0, 0, 0.6);
   }
 
   .overlay-spinner {
     position: absolute;
     top: 25%;
-    bottom: 0;
     left: 25%;
-    right: 0;
     height: 50%;
     width: 50%;
-  }
-
-  .text {
-    width: 90%;
-    color: white;
-    font-size: 20px;
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    -ms-transform: translate(-50%, -50%);
   }
 
   .spinner-border {

--- a/src/app/components/gallery-album-jumbotron/gallery-album-jumbotron.component.html
+++ b/src/app/components/gallery-album-jumbotron/gallery-album-jumbotron.component.html
@@ -1,41 +1,34 @@
 <div class="imageContainer">
-  <div class="gradient-colour">
-    <img
-      alt="jumbotron album cover"
-      class="album-jumbotron no-select"
-      [lazyLoad]="albumCoverPicture()"
-    />
-  </div>
+  <img
+    alt="jumbotron album cover"
+    class="album-jumbotron no-select"
+    [lazyLoad]="albumCoverPicture()"
+  />
+  <div class="gradient-colour"></div>
   <div class="jumb-text">
-    <h1 class="animate__animated animate__fadeInDown no-select">
+    <h1 class="animate__animated animate__fadeInUp no-select">
       {{ albumTitle() }}
       @if (socialMediaLinks() && socialMediaLinks().instagram) {
-      <a
-        class="jumb-text__link__padding"
-        href="{{ socialMediaLinks().instagram }}"
-      >
-        <fa-icon [icon]="icons.instagram" />
-      </a>
-      } @if (socialMediaLinks() && socialMediaLinks().facebook) {
-      <a
-        class="jumb-text__link__padding"
-        href="{{ socialMediaLinks().facebook }}"
-      >
-        <fa-icon [icon]="icons.facebook" />
-      </a>
-      } @if (socialMediaLinks() && socialMediaLinks().twitter) {
-      <a class="jumb-text__link__padding" href="{{ socialMediaLinks().twitter }}">
-        <fa-icon [icon]="icons.twitter" />
-      </a>
-      } @if (socialMediaLinks() && socialMediaLinks().weibo) {
-      <a class="jumb-text__link__padding" href="{{ socialMediaLinks().weibo }}">
-        <fa-icon [icon]="icons.weibo" />
-      </a>
+        <a class="jumb-text__link__padding" href="{{ socialMediaLinks().instagram }}">
+          <fa-icon [icon]="icons.instagram" />
+        </a>
+      }
+      @if (socialMediaLinks() && socialMediaLinks().facebook) {
+        <a class="jumb-text__link__padding" href="{{ socialMediaLinks().facebook }}">
+          <fa-icon [icon]="icons.facebook" />
+        </a>
+      }
+      @if (socialMediaLinks() && socialMediaLinks().twitter) {
+        <a class="jumb-text__link__padding" href="{{ socialMediaLinks().twitter }}">
+          <fa-icon [icon]="icons.twitter" />
+        </a>
+      }
+      @if (socialMediaLinks() && socialMediaLinks().weibo) {
+        <a class="jumb-text__link__padding" href="{{ socialMediaLinks().weibo }}">
+          <fa-icon [icon]="icons.weibo" />
+        </a>
       }
     </h1>
-
-    <h5 class="animate__animated animate__fadeInDown no-select">
-      {{ albumSubtitle() }}
-    </h5>
+    <h5 class="animate__animated animate__fadeInUp no-select">{{ albumSubtitle() }}</h5>
   </div>
 </div>

--- a/src/app/components/gallery-album-jumbotron/gallery-album-jumbotron.component.scss
+++ b/src/app/components/gallery-album-jumbotron/gallery-album-jumbotron.component.scss
@@ -1,46 +1,75 @@
 :host {
-
   .imageContainer {
-    height: 300px;
-    color: white;
-    width: 100%;
     position: relative;
+    width: 100%;
+    height: 380px;
+    overflow: hidden;
+    color: #fff;
+
+    @media (max-width: 600px) {
+      height: 240px;
+    }
   }
 
   img.album-jumbotron {
     opacity: 0;
-    -moz-transition: opacity 1.5s;
-    -webkit-transition: opacity 1.5s;
-    transition: opacity 1.5s;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    transition: opacity 1.2s ease;
   }
 
   img.album-jumbotron.ng-lazyloaded {
-    opacity: 0.5;
-  }
-
-  .jumb-text__link__padding {
-    padding: 0 3px;
-  }
-
-  .album-jumbotron {
-    object-fit: cover;
-    width: 100%;
-    height: 300px;
-    filter: alpha(opacity=50);
+    opacity: 1;
   }
 
   .gradient-colour {
-    background-color: black;
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.85) 0%,
+      rgba(0, 0, 0, 0.3) 50%,
+      rgba(0, 0, 0, 0.1) 100%
+    );
+    pointer-events: none;
   }
 
   .jumb-text {
-    // TODO Need to rewrite this
-    width: 90%;
-    text-align: center;
     position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    -ms-transform: translate(-50%, -50%);
+    bottom: 24px;
+    left: 24px;
+    right: 24px;
+    text-align: left;
+
+    h1 {
+      font-size: 2rem;
+      font-weight: 800;
+      letter-spacing: -0.02em;
+      margin: 0 0 0.25rem;
+      line-height: 1.1;
+
+      @media (max-width: 600px) {
+        font-size: 1.4rem;
+      }
+    }
+
+    h5 {
+      font-size: 0.85rem;
+      font-weight: 400;
+      color: rgba(255, 255, 255, 0.7);
+      margin: 0;
+    }
+  }
+
+  .jumb-text__link__padding {
+    padding: 0 4px;
+    color: rgba(255, 255, 255, 0.75);
+    transition: color 0.2s ease;
+
+    &:hover {
+      color: #fff;
+    }
   }
 }

--- a/src/app/pages/galleries/gallery-album-listing/gallery-album-listing.component.html
+++ b/src/app/pages/galleries/gallery-album-listing/gallery-album-listing.component.html
@@ -1,32 +1,19 @@
-<div class="image-alignment">
-  <h2 class="album-text animate__animated animate__fadeInDown">Albums</h2>
-  <hr class="animate__animated animate__fadeInDown" />
-  <h6 class="animate__animated animate__fadeInDown">
-    <u>Camera and lens usages</u>
-    <ul>
-      <li>Nikon D810</li>
-      <ul>
-        <li>Nikon AF-S NIKKOR 24mm f/1.4G</li>
-        <li>Nikon AF-S NIKKOR 50mm f/1.8G</li>
-      </ul>
-    </ul>
-  </h6>
-  <hr class="animate__animated animate__fadeInDown" data-wow-delay="1.4s" />
+<div class="listing-page animate__animated animate__fadeIn">
   <pagination-controls
     (pageChange)="currentSelectedPage = $event"
     autoHide="true"
   ></pagination-controls>
-  @for (item of coverContent | async | paginate : { itemsPerPage: 20,
-  currentPage: currentSelectedPage }; track item.albumId) {
-  <a>
-    <app-gallery-album-cover
-      [imgUrl]="item.imgUrl"
-      [albumTitle]="item.albumTitle"
-      [translateX]="item.translateX"
-      [translateY]="item.translateY"
-      [routerLink]="item.albumId"
-    >
-    </app-gallery-album-cover>
-  </a>
-  }
+
+  <div class="album-grid">
+    @for (item of coverContent | async | paginate : { itemsPerPage: 20, currentPage: currentSelectedPage }; track item.albumId) {
+      <a class="album-grid__item" [routerLink]="item.albumId">
+        <app-gallery-album-cover
+          [imgUrl]="item.imgUrl"
+          [albumTitle]="item.albumTitle"
+          [translateX]="item.translateX"
+          [translateY]="item.translateY"
+        ></app-gallery-album-cover>
+      </a>
+    }
+  </div>
 </div>

--- a/src/app/pages/galleries/gallery-album-listing/gallery-album-listing.component.scss
+++ b/src/app/pages/galleries/gallery-album-listing/gallery-album-listing.component.scss
@@ -1,28 +1,53 @@
+$border: rgba(255, 255, 255, 0.1);
+$muted: rgba(255, 255, 255, 0.5);
+
 :host {
   display: block;
-  padding-top: 24px;
+  padding: 24px 20px 48px;
+}
+
+.album-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.album-grid__item {
+  display: block;
+  text-decoration: none;
 
   app-gallery-album-cover {
-    display: inline-block;
+    display: block;
+  }
+}
+
+::ng-deep .ngx-pagination {
+  text-align: center;
+  padding: 0;
+  margin-bottom: 1.5rem !important;
+
+  li a,
+  li span {
+    color: rgba(255, 255, 255, 0.7) !important;
+    background: transparent !important;
+    transition: color 0.2s ease;
   }
 
-  div.image-alignment {
-    text-align: center;
+  li a:hover,
+  li span:hover {
+    color: #fff !important;
+    background: rgba(255, 255, 255, 0.1) !important;
+    border-radius: 4px;
   }
 
-  .album-text {
-    color: white;
+  .current span {
+    background: rgba(255, 255, 255, 0.18) !important;
+    border-radius: 4px;
+    color: #fff !important;
   }
 
-  hr {
-    background-color: white;
-  }
-
-  ul {
-    padding: 0;
-  }
-
-  li {
-    list-style-type: none;
+  .disabled {
+    cursor: not-allowed;
+    opacity: 0.35;
   }
 }

--- a/src/app/pages/galleries/gallery-album/gallery-album.component.html
+++ b/src/app/pages/galleries/gallery-album/gallery-album.component.html
@@ -1,42 +1,32 @@
-<a class="gallery-album__return-link" routerLink="/photography"
-  ><fa-icon [icon]="icons.backToAlbum" />Return to albums</a
-  >
-  <hr class="animate__animated animate__fadeInDown" />
+<div class="album-page animate__animated animate__fadeIn">
+  <nav class="breadcrumb" aria-label="breadcrumb">
+    <a class="breadcrumb__link" routerLink="/photography">Photography</a>
+    <span class="breadcrumb__separator">/</span>
+    <span class="breadcrumb__current">{{ (albumData | async)?.albumTitle }}</span>
+  </nav>
+
   <app-gallery-album-jumbotron
     [albumTitle]="(albumData | async).albumTitle"
     [albumSubtitle]="(albumData | async).albumSubtitle"
     [albumCoverPicture]="(albumData | async).imgUrl"
     [socialMediaLinks]="(albumData | async).socialMediaLinks"
-    >
-  </app-gallery-album-jumbotron>
+  ></app-gallery-album-jumbotron>
 
-  <hr class="hr-light mt-4 animate__animated animate__fadeInDown" />
-  <pagination-controls
-    (pageChange)="pageNumber = $event"
-    autoHide="true"
-  ></pagination-controls>
-
-  <div class="gallery-album__image__center">
-    @for (
-      item of (albumData | async).albumImages
-      | paginate : { itemsPerPage: 40, currentPage: pageNumber }
-      ; track
-      item) {
-      <a
-        >
+  <div class="photo-grid">
+    @for (item of (albumData | async).albumImages; track item) {
+      <div class="photo-grid__item">
         <app-gallery-album-cover
           (click)="openModal(item.imageId, item.imgUrl, item.horizontalOrient)"
           (hasImageLoadedEmitter)="allowOpenModal($event)"
           [imgUrl]="item.imgUrl"
           [translateX]="item.translateX"
           [translateY]="item.translateY"
-          >
-        </app-gallery-album-cover>
-      </a>
+        ></app-gallery-album-cover>
+      </div>
     }
   </div>
 
   <app-overlay-container
     [albumSet]="(albumData | async).albumImages"
-    >
-  </app-overlay-container>
+  ></app-overlay-container>
+</div>

--- a/src/app/pages/galleries/gallery-album/gallery-album.component.scss
+++ b/src/app/pages/galleries/gallery-album/gallery-album.component.scss
@@ -1,82 +1,54 @@
+$border: rgba(255, 255, 255, 0.1);
+$muted: rgba(255, 255, 255, 0.5);
+
 :host {
-  .gallery-album__return-link {
-    display: inline-block;
-    margin-left: 20px;
-    padding-top: 16px;
-  }
+  display: block;
+}
 
-  fa-icon {
-    padding-right: 5px;
-  }
+.album-page {
+  padding-bottom: 48px;
+}
 
-  .jumb-content {
-    padding-top: 150px;
-    padding-bottom: 150px;
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 16px 20px;
+  font-size: 0.8rem;
+}
+
+.breadcrumb__link {
+  color: $muted;
+  text-decoration: none;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: #fff;
   }
+}
+
+.breadcrumb__separator {
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.breadcrumb__current {
+  color: #fff;
+  font-weight: 600;
+}
+
+
+.photo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 8px;
+  padding: 0 20px;
+}
+
+.photo-grid__item {
+  display: block;
+  cursor: pointer;
 
   app-gallery-album-cover {
-    display: inline-block;
+    display: block;
   }
-
-  .gallery-album__image__center {
-    text-align: center;
-  }
-
-  ::ng-deep .ngx-pagination {
-    text-align: center;
-
-    & span {
-      color: white;
-    }
-
-    & .pagination-next a {
-      color: white;
-      -moz-transition: color 0.5s;
-      -webkit-transition: color 0.5s;
-      transition: color 0.5s;
-
-      &:hover {
-        color: black;
-        border-radius: 900px;
-        -moz-transition: color 0.5s;
-        -webkit-transition: color 0.5s;
-        transition: color 0.5s;
-      }
-    }
-
-    & .pagination-previous a {
-      color: white;
-      -moz-transition: color 0.5s;
-      -webkit-transition: color 0.5s;
-      transition: color 0.5s;
-
-      &:hover {
-        color: black;
-        border-radius: 900px;
-        -moz-transition: color 0.5s;
-        -webkit-transition: color 0.5s;
-        transition: color 0.5s;
-      }
-    }
-
-    & .disabled {
-      cursor: not-allowed;
-    }
-
-    & a {
-      -moz-transition: color 0.5s;
-      -webkit-transition: color 0.5s;
-      transition: color 0.5s;
-      &:hover span {
-        color: black;
-        -moz-transition: color 0.5s;
-        -webkit-transition: color 0.5s;
-        transition: color 0.5s;
-      }
-    }
-
-    & .current {
-      background: grey;
-    }
-  } //end ngx-pagination
-} //end :host
+}

--- a/src/app/pages/galleries/gallery-album/gallery-album.component.ts
+++ b/src/app/pages/galleries/gallery-album/gallery-album.component.ts
@@ -7,13 +7,10 @@ import { IGalleryCover } from '../../../state-management/gallery-list/gallery-co
 import { AppFacade } from '../../../state-management/app/app.facade';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Title } from '@angular/platform-browser';
-import { faHandPointLeft } from '@fortawesome/free-solid-svg-icons';
 import { OverlayContainerComponent } from '../../../components/overlay/overlay-container/overlay-container.component';
 import { GalleryAlbumCoverComponent } from '../../../components/gallery-album-cover/gallery-album-cover.component';
 import { AsyncPipe } from '@angular/common';
-import { NgxPaginationModule } from 'ngx-pagination';
 import { GalleryAlbumJumbotronComponent } from '../../../components/gallery-album-jumbotron/gallery-album-jumbotron.component';
-import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 
 @Component({
     selector: 'app-gallery-album',
@@ -21,17 +18,13 @@ import { FaIconComponent } from '@fortawesome/angular-fontawesome';
     styleUrl: './gallery-album.component.scss',
     imports: [
     RouterLink,
-    FaIconComponent,
     GalleryAlbumJumbotronComponent,
-    NgxPaginationModule,
     GalleryAlbumCoverComponent,
     OverlayContainerComponent,
     AsyncPipe
 ]
 })
 export class GalleryAlbumComponent {
-  public pageNumber: number = 1;
-
   private destroyRef: DestroyRef = inject(DestroyRef);
 
   private loadedImagesUrl: Array<string> = [];
@@ -41,9 +34,6 @@ export class GalleryAlbumComponent {
     imgUrl: '',
   });
 
-  public icons = {
-    backToAlbum: faHandPointLeft,
-  };
 
   constructor(
     private activatedRoute: ActivatedRoute,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -60,6 +60,10 @@ a {
   transition: color 0.5s ease;
 }
 
+body.noScroll app-header {
+  display: none;
+}
+
 a:hover,
 a:hover span {
   text-decoration: none;


### PR DESCRIPTION
## Summary

- **Album listing**: CSS grid (`auto-fill, minmax(240px, 1fr)`), removed redundant title/header info — photos lead immediately
- **Album covers**: fluid `aspect-ratio: 1/1` tiles, bottom-gradient overlay, album title anchored bottom-left (editorial caption style), rounded corners, dark placeholder while loading
- **Album view**: breadcrumb (`Photography / Album Name`) replacing the hand-pointer back button, full-width jumbotron at 380px with fully opaque image and bottom gradient, title left-aligned at bottom
- **Lazy loading**: removed pagination from album view entirely — all photos load as the user scrolls via `ng-lazyload-image`
- **Lightbox**: sticky nav hides when modal opens (`body.noScroll app-header { display: none }`)
- **Image coverage fix**: `min-width: 100%; max-width: none` on album cover images ensures no empty edges on fluid containers

## Test plan

- [ ] `/photography` — grid loads, album titles appear on hover (bottom-left), hover scale works
- [ ] Enter an album — breadcrumb shows correct album name, jumbotron image is fully opaque
- [ ] Scroll through photos — images lazy-load as they enter viewport, no pagination controls
- [ ] Click a photo — lightbox opens full screen, nav bar is hidden
- [ ] Escape / arrow keys / swipe close/navigate the lightbox
- [ ] Mobile layout — grid collapses correctly, breadcrumb readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)