### PR TITLE
Remove ngx-pagination dependency entirely

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "core-js": "3.8.3",
         "ng-lazyload-image": "^9.1.3",
         "ngx-device-detector": "11.0.0",
-        "ngx-pagination": "^6.0.3",
         "rxjs": "6.6.3",
         "screenfull": "5.1.0",
         "smoothscroll-polyfill": "^0.4.3",
@@ -6924,17 +6923,6 @@
       "peerDependencies": {
         "@angular/common": "^21.0.0",
         "@angular/core": "^21.0.0"
-      }
-    },
-    "node_modules/ngx-pagination": {
-      "version": "6.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/common": ">=13.0.0",
-        "@angular/core": ">=13.0.0"
       }
     },
     "node_modules/node-addon-api": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "core-js": "3.8.3",
     "ng-lazyload-image": "^9.1.3",
     "ngx-device-detector": "11.0.0",
-    "ngx-pagination": "^6.0.3",
     "rxjs": "6.6.3",
     "screenfull": "5.1.0",
     "smoothscroll-polyfill": "^0.4.3",

--- a/src/app/pages/galleries/gallery-album-listing/gallery-album-listing.component.html
+++ b/src/app/pages/galleries/gallery-album-listing/gallery-album-listing.component.html
@@ -1,11 +1,6 @@
 <div class="listing-page animate__animated animate__fadeIn">
-  <pagination-controls
-    (pageChange)="currentSelectedPage = $event"
-    autoHide="true"
-  ></pagination-controls>
-
   <div class="album-grid">
-    @for (item of coverContent | async | paginate : { itemsPerPage: 20, currentPage: currentSelectedPage }; track item.albumId) {
+    @for (item of coverContent | async; track item.albumId) {
       <a class="album-grid__item" [routerLink]="item.albumId">
         <app-gallery-album-cover
           [imgUrl]="item.imgUrl"

--- a/src/app/pages/galleries/gallery-album-listing/gallery-album-listing.component.ts
+++ b/src/app/pages/galleries/gallery-album-listing/gallery-album-listing.component.ts
@@ -6,14 +6,11 @@ import { IGalleryCover } from '../../../state-management/gallery-list/gallery-co
 import { AppFacade } from '../../../state-management/app/app.facade';
 import { RouterLink } from '@angular/router';
 import { GalleryAlbumCoverComponent } from '../../../components/gallery-album-cover/gallery-album-cover.component';
-import { NgxPaginationModule } from 'ngx-pagination';
-
 @Component({
     selector: 'app-galleries',
     templateUrl: './gallery-album-listing.component.html',
     styleUrl: './gallery-album-listing.component.scss',
     imports: [
-        NgxPaginationModule,
         GalleryAlbumCoverComponent,
         RouterLink,
         AsyncPipe,
@@ -25,8 +22,6 @@ export class GalleryAlbumListingComponent implements OnInit {
   private location = inject(PlatformLocation);
 
   public coverContent: Observable<IGalleryCover[]>;
-
-  public currentSelectedPage: number = 1;
 
   public ngOnInit(): void {
     this.coverContent = this.galleryFacade.galleryList$;

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,6 @@ import { withInMemoryScrolling, provideRouter, Routes } from '@angular/router';
 import { listOfReducers } from './app/state-management/ngrx-index';
 import { provideStore, ActionReducer } from '@ngrx/store';
 import { provideAnimations } from '@angular/platform-browser/animations';
-import { NgxPaginationModule } from 'ngx-pagination';
 import { DeviceDetectorService } from 'ngx-device-detector';
 import { provideEffects, Actions } from '@ngrx/effects';
 import {
@@ -100,7 +99,6 @@ const appRoutes: Routes = [
 bootstrapApplication(AppComponent, {
   providers: [
     provideZoneChangeDetection(),
-    importProvidersFrom(NgxPaginationModule),
     provideStore(listOfReducers, { metaReducers }),
     provideEffects([GalleryEffects]),
     AppFacade,


### PR DESCRIPTION
## Summary

- Remove pagination from album listing page — all albums now load at once
- Remove `NgxPaginationModule` from `main.ts` providers
- Uninstall `ngx-pagination` package from `package.json` / `node_modules`
- Bundle size reduced from 2.37MB → 2.33MB

## Test plan

- [ ] `/photography` — all albums load without pagination controls
- [ ] No console errors related to pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)