### PR TITLE
Fix portrait image alignment gap in LSCC2016 album

### DIFF
--- a/src/assets/gallery-content.json
+++ b/src/assets/gallery-content.json
@@ -2030,7 +2030,7 @@
 			{
 				"imageId": 14,
 				"imgUrl": "https://farm2.staticflickr.com/1559/24650517514_1487e49e31_k.jpg",
-				"translateX": 10,
+				"translateX": 0,
 				"translateY": -10,
 				"horizontalOrient": false
 			},


### PR DESCRIPTION
## Summary
- Fixed a visible gap appearing on the left side of imageId 14 in the LSCC2016 album before hover
- Root cause: `translateX: 10` (positive) was the only portrait image with a positive horizontal offset, shifting the image right and exposing the container background
- Set `translateX: 0` to centre the image, fully covering the container at all times

## Test plan
- [ ] Visit `/photography/LSCC2016`
- [ ] Confirm imageId 14 (portrait image) shows no gap before hovering
- [ ] Confirm hover scale effect still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)