### PR TITLE
Prevent page scroll when image lightbox is open

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -60,8 +60,12 @@ a {
   transition: color 0.5s ease;
 }
 
-body.noScroll app-header {
-  display: none;
+body.noScroll {
+  overflow: hidden;
+
+  app-header {
+    display: none;
+  }
 }
 
 a:hover,


### PR DESCRIPTION
## Summary
- Added `overflow: hidden` to `body.noScroll` in global styles
- The `noScroll` class is already toggled by the overlay component when an image is selected, but scroll prevention was never applied
- Page is now fully locked while the lightbox is open

## Test plan
- [ ] Open any album and click an image to zoom in
- [ ] Confirm the page cannot be scrolled while the lightbox is open
- [ ] Confirm scrolling resumes normally after closing the lightbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)