### PR TITLE
Cache BTC API responses to prevent redundant calls on navigation

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
 
   webServer: {
     command: "ng serve",
-    url: "http:/localhost:4200",
+    url: "http://localhost:4200",
     reuseExistingServer: !process.env.CI,
     stdout: "ignore",
     stderr: "pipe",

--- a/src/app/api/coincap.service.ts
+++ b/src/app/api/coincap.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { environment } from '../../environments/environment';
 import { Observable } from 'rxjs';
+import { shareReplay } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -9,11 +10,24 @@ import { Observable } from 'rxjs';
 export class CoincapService {
   private httpClient: HttpClient = inject(HttpClient);
 
+  private btcAssetData$: Observable<any>;
+  private ratesData$: Observable<any>;
+
   public getBtcAssetData(): Observable<any> {
-    return this.httpClient.get(environment.coinCapApi + `/bitcoin-markets`);
+    if (!this.btcAssetData$) {
+      this.btcAssetData$ = this.httpClient
+        .get(environment.coinCapApi + `/bitcoin-markets`)
+        .pipe(shareReplay(1));
+    }
+    return this.btcAssetData$;
   }
 
   public getRatesData(): Observable<any> {
-    return this.httpClient.get(environment.coinCapApi + `/rates`);
+    if (!this.ratesData$) {
+      this.ratesData$ = this.httpClient
+        .get(environment.coinCapApi + `/rates`)
+        .pipe(shareReplay(1));
+    }
+    return this.ratesData$;
   }
 }

--- a/src/app/pages/converter/converter.component.ts
+++ b/src/app/pages/converter/converter.component.ts
@@ -8,7 +8,6 @@ import { AsyncPipe, CurrencyPipe } from '@angular/common';
 @Component({
     selector: 'app-converter',
     imports: [AsyncPipe, CurrencyPipe, FormsModule],
-    providers: [CoincapService],
     templateUrl: './converter.component.html',
     styleUrl: './converter.component.scss'
 })


### PR DESCRIPTION
## Summary
- `CoincapService` now lazily initialises each HTTP call and caches it with `shareReplay(1)` — the API is only hit once per app session regardless of how many times the user navigates to `/converter`
- Removed `CoincapService` from `converter.component.ts` `providers` array — it was overriding the root singleton and creating a fresh instance (and fresh API calls) on every navigation
- Fixed a typo in `playwright.config.ts` where `webServer.url` had a single slash (`http:/localhost:4200`) causing `npm run pw` to fail when no dev server was already running

## Test plan
- [ ] Navigate to `/converter` — API loads correctly
- [ ] Navigate away to Home, Resume, etc., then back to `/converter` multiple times — confirm no additional network requests to the CoinCap API endpoints
- [ ] Confirm `npm run pw` starts the dev server and runs tests successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)