### PR TITLE
Fix visible 'Loading...' text on resume page spinner

### DIFF
--- a/src/app/pages/profile/profile.component.html
+++ b/src/app/pages/profile/profile.component.html
@@ -81,7 +81,7 @@
 } @else {
 <div class="loading-spinner">
   <div class="spinner-border">
-    <span class="sr-only">Loading...</span>
+    <span class="visually-hidden">Loading...</span>
   </div>
 </div>
 }


### PR DESCRIPTION
## Summary
- Replaced `sr-only` with `visually-hidden` on the loading spinner's accessible label
- Bootstrap 5 removed the `sr-only` class in favour of `visually-hidden` — without the correct class the text was rendering visibly inside the spinning border during page load

## Test plan
- [ ] Navigate to `/resume` and observe the loading spinner
- [ ] Confirm no "Loading..." text is visible while the spinner is showing

🤖 Generated with [Claude Code](https://claude.com/claude-code)