### PR TITLE
Add Playwright CI workflow with parallel sharding

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -75,3 +75,12 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 14
+
+  all-tests-passed:
+    name: All Playwright tests passed
+    needs: playwright
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - run: echo "All shards completed successfully"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,73 @@
+name: Playwright Tests
+run-name: E2E Tests
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+jobs:
+  playwright:
+    name: "Playwright shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [1, 2, 3]
+        shardTotal: [3]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4.0.1
+        with:
+          node-version: "20.x"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --reporter=blob
+
+      - name: Upload blob report
+        uses: actions/upload-artifact@v4.3.0
+        if: always()
+        with:
+          name: blob-report-${{ matrix.shardIndex }}
+          path: blob-report/
+          retention-days: 1
+
+  merge-reports:
+    name: Merge Playwright reports
+    needs: playwright
+    runs-on: ubuntu-24.04
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4.0.1
+        with:
+          node-version: "20.x"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Download blob reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: blob-report-*
+          path: all-blob-reports
+          merge-multiple: true
+
+      - name: Merge into HTML report
+        run: npx playwright merge-reports --reporter=html ./all-blob-reports
+
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4.3.0
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,6 +9,8 @@ jobs:
   playwright:
     name: "Playwright shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }}"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -44,6 +46,8 @@ jobs:
     needs: playwright
     runs-on: ubuntu-24.04
     if: always()
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/playwright.yml` to run E2E tests on PRs to `master`
- Uses a 3-shard matrix strategy to run tests in parallel, reducing overall runtime
- Merges blob reports from each shard into a single HTML report artifact (retained 14 days)

## Test plan
- [ ] Verify the workflow triggers on a PR to `master`
- [ ] Confirm all 3 shard jobs complete and the `merge-reports` job produces a downloadable HTML report
- [ ] Confirm `fail-fast: false` allows all shards to report even when one fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)