### PR TITLE
Fix modal image appearing over-zoomed at 100% browser zoom

### DIFF
--- a/src/app/components/overlay/overlay-container/overlay-container.component.scss
+++ b/src/app/components/overlay/overlay-container/overlay-container.component.scss
@@ -26,14 +26,14 @@
     transform: translate(-50%, -50%);
 
     &.horizontal-image {
-      max-width: 1900px;
-      width: 100%;
+      max-width: 90vw;
+      width: auto;
       height: auto;
     }
 
     &.vertical-image {
       width: auto;
-      height: 100%;
+      max-height: 90vh;
     }
   }
 


### PR DESCRIPTION
## Summary
- `height: 100%` and `width: 100%` on `position: fixed` elements resolve to full viewport dimensions, causing lightbox images to fill the entire screen
- Replaced with `max-height: 90vh` for vertical images and `max-width: 90vw` for horizontal images so they scale naturally with comfortable padding

## Test plan
- [ ] Open the photography/gallery page and click an image to open the lightbox
- [ ] Verify vertical images no longer fill the full viewport height
- [ ] Verify horizontal images no longer fill the full viewport width
- [ ] Test at different browser zoom levels (75%, 100%, 125%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)