### PR TITLE
Add mobile-friendly menu and fullscreen controls to bomb game

### DIFF
--- a/src/app/pages/bomb-game/bomb-defusal-game.ts
+++ b/src/app/pages/bomb-game/bomb-defusal-game.ts
@@ -207,8 +207,14 @@ class BombDefusalScene extends Phaser.Scene {
     });
 
     if (this.sys.game.device.fullscreen.available) {
-      this.scale.on('enterfullscreen', () => this.fullscreenButton.setText(fullscreenLabel()));
-      this.scale.on('leavefullscreen', () => this.fullscreenButton.setText(fullscreenLabel()));
+      const onFullscreenChange = () => {
+        this.fullscreenButton.setText(fullscreenLabel());
+        // The container's box only settles after the browser applies the
+        // :fullscreen CSS rules, so defer the resize until the next frame.
+        requestAnimationFrame(() => this.scale.refresh());
+      };
+      this.scale.on('enterfullscreen', onFullscreenChange);
+      this.scale.on('leavefullscreen', onFullscreenChange);
     } else {
       this.fullscreenButton.setVisible(false);
     }
@@ -646,6 +652,10 @@ export function createBombDefusalGame(parent: HTMLElement): Phaser.Game {
     height: 640,
     backgroundColor: '#111111',
     parent,
+    // Fullscreen the actual container (rather than letting Phaser create its own
+    // wrapper div) so our :fullscreen CSS applies and the scale manager measures
+    // the real fullscreen bounds.
+    fullscreenTarget: parent,
     scale: {
       mode: Phaser.Scale.FIT,
       autoCenter: Phaser.Scale.CENTER_BOTH,

--- a/src/app/pages/bomb-game/bomb-defusal-game.ts
+++ b/src/app/pages/bomb-game/bomb-defusal-game.ts
@@ -27,6 +27,8 @@ class BombDefusalScene extends Phaser.Scene {
   private needleGfx!: Phaser.GameObjects.Graphics;
   private overlayGfx!: Phaser.GameObjects.Graphics;
 
+  private menuButton!: Phaser.GameObjects.Text;
+
   private pauseOverlayGfx!: Phaser.GameObjects.Graphics;
   private pauseTitleText!: Phaser.GameObjects.Text;
   private resumeButton!: Phaser.GameObjects.Text;
@@ -167,6 +169,23 @@ class BombDefusalScene extends Phaser.Scene {
 
     this.pickGreenZones();
 
+    this.menuButton = this.add
+      .text(780, 50, '☰ Menu', {
+        fontSize: '20px',
+        color: '#ffffff',
+        backgroundColor: '#333333',
+        padding: { x: 12, y: 6 },
+      })
+      .setOrigin(1, 0)
+      .setDepth(21)
+      .setInteractive({ useHandCursor: true });
+    this.menuButton.on('pointerover', () => this.menuButton.setBackgroundColor('#555555'));
+    this.menuButton.on('pointerout', () => this.menuButton.setBackgroundColor('#333333'));
+    this.menuButton.on('pointerdown', (_pointer: Phaser.Input.Pointer, _x: number, _y: number, event: { stopPropagation: () => void }) => {
+      event.stopPropagation();
+      this.toggleMenu();
+    });
+
     this.pauseOverlayGfx = this.add.graphics().setDepth(20).setVisible(false);
     this.pauseTitleText = this.add
       .text(CENTER.x, CENTER.y - 90, 'Paused', { fontSize: '36px', color: '#ffffff' })
@@ -298,19 +317,21 @@ class BombDefusalScene extends Phaser.Scene {
 
     this.input.on('pointerdown', triggerAction);
     this.input.keyboard?.on('keydown-SPACE', triggerAction);
-    this.input.keyboard?.on('keydown-ESC', () => {
-      if (this.gameOver) return;
-      if (this.paused && this.showingOptions) {
-        this.setShowingOptions(false);
-        return;
-      }
-      this.setPaused(!this.paused);
-    });
+    this.input.keyboard?.on('keydown-ESC', () => this.toggleMenu());
     this.input.keyboard?.on('keydown-R', () => {
       if (!this.paused || this.showingOptions) return;
       this.setPaused(false);
       this.restart();
     });
+  }
+
+  private toggleMenu(): void {
+    if (this.gameOver) return;
+    if (this.paused && this.showingOptions) {
+      this.setShowingOptions(false);
+      return;
+    }
+    this.setPaused(!this.paused);
   }
 
   private setPaused(value: boolean): void {

--- a/src/app/pages/bomb-game/bomb-defusal-game.ts
+++ b/src/app/pages/bomb-game/bomb-defusal-game.ts
@@ -28,6 +28,7 @@ class BombDefusalScene extends Phaser.Scene {
   private overlayGfx!: Phaser.GameObjects.Graphics;
 
   private menuButton!: Phaser.GameObjects.Text;
+  private fullscreenButton!: Phaser.GameObjects.Text;
 
   private pauseOverlayGfx!: Phaser.GameObjects.Graphics;
   private pauseTitleText!: Phaser.GameObjects.Text;
@@ -185,6 +186,32 @@ class BombDefusalScene extends Phaser.Scene {
       event.stopPropagation();
       this.toggleMenu();
     });
+
+    const fullscreenLabel = () => (this.scale.isFullscreen ? '⛶ Exit Fullscreen' : '⛶ Fullscreen');
+
+    this.fullscreenButton = this.add
+      .text(780, 620, fullscreenLabel(), {
+        fontSize: '20px',
+        color: '#ffffff',
+        backgroundColor: '#333333',
+        padding: { x: 12, y: 6 },
+      })
+      .setOrigin(1, 1)
+      .setDepth(21)
+      .setInteractive({ useHandCursor: true });
+    this.fullscreenButton.on('pointerover', () => this.fullscreenButton.setBackgroundColor('#555555'));
+    this.fullscreenButton.on('pointerout', () => this.fullscreenButton.setBackgroundColor('#333333'));
+    this.fullscreenButton.on('pointerdown', (_pointer: Phaser.Input.Pointer, _x: number, _y: number, event: { stopPropagation: () => void }) => {
+      event.stopPropagation();
+      this.scale.toggleFullscreen();
+    });
+
+    if (this.sys.game.device.fullscreen.available) {
+      this.scale.on('enterfullscreen', () => this.fullscreenButton.setText(fullscreenLabel()));
+      this.scale.on('leavefullscreen', () => this.fullscreenButton.setText(fullscreenLabel()));
+    } else {
+      this.fullscreenButton.setVisible(false);
+    }
 
     this.pauseOverlayGfx = this.add.graphics().setDepth(20).setVisible(false);
     this.pauseTitleText = this.add

--- a/src/app/pages/bomb-game/bomb-game.component.scss
+++ b/src/app/pages/bomb-game/bomb-game.component.scss
@@ -8,5 +8,16 @@
     width: 100%;
     max-width: 800px;
     touch-action: none;
+
+    &:fullscreen,
+    &:-webkit-full-screen {
+      max-width: none;
+      width: 100vw;
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #000;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds an on-screen "Menu" button so touch users can open the pause/options menu (previously only reachable via ESC)
- Adds a bottom-right "Fullscreen" toggle button using Phaser's Fullscreen API
- Fixes fullscreen sizing: Phaser was creating its own wrapper div as the fullscreen target instead of our container, causing the game to render cropped in the top-left and resume undersized after exiting fullscreen

## Test plan
- [x] `npm run build` succeeds
- [x] Manually verified fullscreen enter/exit renders correctly in browser
- [ ] Verify menu button and fullscreen button on an actual mobile device