### PR TITLE
Fix bomb-game fullscreen not stretching to bottom on mobile

### DIFF
--- a/src/app/pages/bomb-game/bomb-game.component.scss
+++ b/src/app/pages/bomb-game/bomb-game.component.scss
@@ -14,6 +14,7 @@
       max-width: none;
       width: 100vw;
       height: 100vh;
+      height: 100dvh;
       display: flex;
       align-items: center;
       justify-content: center;


### PR DESCRIPTION
## Summary
- Mobile browsers size `100vh` to the largest possible viewport (with the address bar collapsed), so the fullscreen bomb-game container ended up taller than the actual visible screen, leaving the black background not stretched to the bottom.
- Added `100dvh` (with `100vh` kept as a fallback) so the container tracks the real visible viewport on mobile.

## Test plan
- [ ] Open bomb-game on a mobile device/emulator, enter fullscreen, and confirm the black background fills the screen to the bottom in both portrait and landscape.