### PR TITLE
Remove high score name entry and storage from bomb-game

### DIFF
--- a/src/app/pages/bomb-game/bomb-defusal-game.ts
+++ b/src/app/pages/bomb-game/bomb-defusal-game.ts
@@ -62,7 +62,6 @@ class BombDefusalScene extends Phaser.Scene {
   private comboStreak = 0;
   private score = 0;
   private highScore = Number(localStorage.getItem('bombDefuseHighScore')) || 0;
-  private highScoreName = localStorage.getItem('bombDefuseHighScoreName') || '';
   private lives = MAX_LIVES;
   private gameOver = false;
   private paused = false;
@@ -113,9 +112,7 @@ class BombDefusalScene extends Phaser.Scene {
   }
 
   private formatHighScoreText(): string {
-    return this.highScoreName
-      ? `High Score: ${this.highScore} (${this.highScoreName})`
-      : `High Score: ${this.highScore}`;
+    return `High Score: ${this.highScore}`;
   }
 
   private pickGreenZones(): void {
@@ -324,9 +321,7 @@ class BombDefusalScene extends Phaser.Scene {
     wireButton(this.volumeUpButton, () => setVolume(this.soundVolume + 0.1));
     wireButton(this.clearHighScoreButton, () => {
       this.highScore = 0;
-      this.highScoreName = '';
       localStorage.removeItem('bombDefuseHighScore');
-      localStorage.removeItem('bombDefuseHighScoreName');
       this.highScoreText.setText(this.formatHighScoreText());
     });
     wireButton(this.optionsBackButton, () => this.setShowingOptions(false));
@@ -497,15 +492,6 @@ class BombDefusalScene extends Phaser.Scene {
       this.highScore = this.score;
       localStorage.setItem('bombDefuseHighScore', String(this.highScore));
       this.highScoreText.setText(this.formatHighScoreText());
-
-      setTimeout(() => {
-        const name = window.prompt('New high score! Enter your name:', this.highScoreName);
-        if (name) {
-          this.highScoreName = name.slice(0, 20);
-          localStorage.setItem('bombDefuseHighScoreName', this.highScoreName);
-          this.highScoreText.setText(this.formatHighScoreText());
-        }
-      }, 0);
     }
   }
 


### PR DESCRIPTION
## Summary
- Removed the `window.prompt` asking for a player name on a new high score.
- Removed the `bombDefuseHighScoreName` localStorage key and all reads/writes/clears of it.
- High score display and reset now only deal with the numeric score.

## Test plan
- [ ] Beat the current high score in bomb-game and confirm no name prompt appears.
- [ ] Confirm the high score text shows only the number.
- [ ] Use the "Clear high score" option and confirm it resets to 0 with no errors.