### PR TITLE
Add CSS fake-fullscreen fallback for browsers without the Fullscreen API

### DIFF
--- a/src/app/pages/bomb-game/bomb-defusal-game.ts
+++ b/src/app/pages/bomb-game/bomb-defusal-game.ts
@@ -29,6 +29,7 @@ class BombDefusalScene extends Phaser.Scene {
 
   private menuButton!: Phaser.GameObjects.Text;
   private fullscreenButton!: Phaser.GameObjects.Text;
+  private fakeFullscreenActive = false;
 
   private pauseOverlayGfx!: Phaser.GameObjects.Graphics;
   private pauseTitleText!: Phaser.GameObjects.Text;
@@ -187,7 +188,8 @@ class BombDefusalScene extends Phaser.Scene {
       this.toggleMenu();
     });
 
-    const fullscreenLabel = () => (this.scale.isFullscreen ? '⛶ Exit Fullscreen' : '⛶ Fullscreen');
+    const fullscreenLabel = () =>
+      this.scale.isFullscreen || this.fakeFullscreenActive ? '⛶ Exit Fullscreen' : '⛶ Fullscreen';
 
     this.fullscreenButton = this.add
       .text(780, 620, fullscreenLabel(), {
@@ -201,9 +203,25 @@ class BombDefusalScene extends Phaser.Scene {
       .setInteractive({ useHandCursor: true });
     this.fullscreenButton.on('pointerover', () => this.fullscreenButton.setBackgroundColor('#555555'));
     this.fullscreenButton.on('pointerout', () => this.fullscreenButton.setBackgroundColor('#333333'));
+
+    const fullscreenClass = 'bomb-game__canvas--fake-fullscreen';
+
     this.fullscreenButton.on('pointerdown', (_pointer: Phaser.Input.Pointer, _x: number, _y: number, event: { stopPropagation: () => void }) => {
       event.stopPropagation();
-      this.scale.toggleFullscreen();
+
+      if (this.sys.game.device.fullscreen.available) {
+        this.scale.toggleFullscreen();
+        return;
+      }
+
+      // Fall back to a CSS-only "fake fullscreen" on browsers (e.g. iOS Safari)
+      // that don't support the Fullscreen API for arbitrary elements.
+      this.fakeFullscreenActive = !this.fakeFullscreenActive;
+      this.game.canvas.parentElement?.classList.toggle(fullscreenClass, this.fakeFullscreenActive);
+      this.fullscreenButton.setText(fullscreenLabel());
+      // The container's box only settles after the browser applies the new
+      // CSS rules, so defer the resize until the next frame.
+      requestAnimationFrame(() => this.scale.refresh());
     });
 
     if (this.sys.game.device.fullscreen.available) {
@@ -215,8 +233,6 @@ class BombDefusalScene extends Phaser.Scene {
       };
       this.scale.on('enterfullscreen', onFullscreenChange);
       this.scale.on('leavefullscreen', onFullscreenChange);
-    } else {
-      this.fullscreenButton.setVisible(false);
     }
 
     this.pauseOverlayGfx = this.add.graphics().setDepth(20).setVisible(false);

--- a/src/app/pages/bomb-game/bomb-game.component.scss
+++ b/src/app/pages/bomb-game/bomb-game.component.scss
@@ -10,14 +10,22 @@
     touch-action: none;
 
     &:fullscreen,
-    &:-webkit-full-screen {
+    &:-webkit-full-screen,
+    &--fake-fullscreen {
       max-width: none;
       width: 100vw;
       height: 100vh;
+      height: 100dvh;
       display: flex;
       align-items: center;
       justify-content: center;
       background: #000;
+    }
+
+    &--fake-fullscreen {
+      position: fixed;
+      inset: 0;
+      z-index: 1000;
     }
   }
 }


### PR DESCRIPTION
## Summary
- The fullscreen button was hiding itself entirely (`setVisible(false)`) whenever `device.fullscreen.available` was `false` — true on iOS Safari, which only supports the Fullscreen API for `<video>` elements, not arbitrary containers.
- Added a CSS-only "fake fullscreen" fallback: a `bomb-game__canvas--fake-fullscreen` class (`position: fixed; inset: 0`, matching the real `:fullscreen` styles) that the button toggles manually on browsers without native support, then triggers `scale.refresh()` so Phaser refits the canvas.
- The button now always shows and works, using real fullscreen where available and the CSS fallback otherwise.

## Test plan
- [ ] On iPhone Safari, tap the fullscreen button in bomb-game and confirm it now appears and expands the game to fill the screen.
- [ ] Tap again and confirm it exits back to the normal layout.
- [ ] On a browser with native Fullscreen support (e.g. Android Chrome, desktop), confirm real fullscreen still works as before.